### PR TITLE
Fix function name in implementation plan

### DIFF
--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -101,7 +101,7 @@
   * **Tasks:**
         1. `uv add duckdb`
         2. In `simgrep/metadata_db.py`:
-            *`create_inmemory_db() -> duckdb.DuckDBPyConnection`.
+            *`create_inmemory_db_connection() -> duckdb.DuckDBPyConnection`.
             * Define schema and create functions for `temp_files (file_id PK, file_path TEXT)` and `temp_chunks (chunk_id PK, file_id FK, usearch_label INT, text_snippet TEXT, start_offset INT, end_offset INT)`.
             * Functions to insert `ChunkData` into these tables. USearch will store `chunk_id` as its label.
         3. Modify `search` command: Populate in-memory DuckDB. After USearch returns `chunk_id`s, query DuckDB to get full `ChunkData`.


### PR DESCRIPTION
## Summary
- update Deliverable 2.3 to refer to `create_inmemory_db_connection`

## Testing
- `make format-check` *(fails: would reformat many files)*
- `make test` *(fails: KeyboardInterrupt while running pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68418af6377c8333bf3357d21cef0708