### PR TITLE
Implement Deliverable 4.2 - incremental indexing

### DIFF
--- a/simgrep/main.py
+++ b/simgrep/main.py
@@ -537,11 +537,9 @@ def index(
 ) -> None:
     """
     Creates or updates a persistent index for the specified path in the default project.
-    WARNING: This command currently WIPES all existing data in the default project and re-indexes from scratch.
+    Files that are unchanged since the last index run will be skipped.
     """
     console.print(f"Starting indexing for path: [green]{path_to_index}[/green]")
-    console.print("[bold yellow]Warning: This will wipe and rebuild the default project's index.[/bold yellow]")
-    # Future: typer.confirm("Are you sure you want to wipe and rebuild the default project index?", abort=True)
 
     try:
         global_simgrep_config: SimgrepConfig = load_or_create_global_config()
@@ -562,7 +560,7 @@ def index(
         )
 
         indexer_instance = Indexer(config=indexer_config, console=console)
-        indexer_instance.index_path(target_path=path_to_index, wipe_existing=True)
+        indexer_instance.index_path(target_path=path_to_index, wipe_existing=False)
 
         console.print(f"[bold green]Successfully indexed '{path_to_index}' into the default project.[/bold green]")
 

--- a/simgrep/processor.py
+++ b/simgrep/processor.py
@@ -4,7 +4,6 @@ from typing import List, Optional, TypedDict, cast
 
 import numpy as np
 import unstructured.partition.auto as auto_partition
-from sentence_transformers import SentenceTransformer
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 from unstructured.documents.elements import Element
 
@@ -121,7 +120,7 @@ def chunk_text_by_tokens(
 def generate_embeddings(
     texts: List[str],
     model_name: str = "sentence-transformers/all-MiniLM-L6-v2",
-    model: Optional[SentenceTransformer] = None,
+    model: Optional[object] = None,
 ) -> np.ndarray:
     """
     Generates vector embeddings for a list of input texts using a specified
@@ -139,8 +138,10 @@ def generate_embeddings(
         RuntimeError: If embedding generation fails.
     """
     try:
-        active_model: SentenceTransformer
+        active_model: "SentenceTransformer"
         if model is None:
+            from sentence_transformers import SentenceTransformer
+
             active_model = SentenceTransformer(model_name)
         else:
             active_model = model

--- a/simgrep/vector_store.py
+++ b/simgrep/vector_store.py
@@ -215,6 +215,19 @@ def search_inmemory_index(
     return results
 
 
+def remove_vectors_from_index(
+    index: usearch.index.Index, labels: List[int]
+) -> None:
+    """Remove vectors identified by labels from a USearch index."""
+    if not labels:
+        return
+    try:
+        index.remove(keys=np.array(labels, dtype=np.int64))
+    except Exception as e:
+        logger.error(f"Failed to remove vectors from USearch index: {e}")
+        raise VectorStoreError("Failed to remove vectors from USearch index") from e
+
+
 def load_persistent_index(index_path: Path) -> Optional[usearch.index.Index]:
     """
     Loads a USearch index from a file.


### PR DESCRIPTION
## Summary
- implement incremental indexing logic in indexer
- support removing and updating metadata in DuckDB
- add vector store helper to remove labels
- load sentence-transformers lazily to avoid heavy dependency at import time
- change index command to reuse existing index instead of wiping
- add integration test for incremental indexing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e27d0d688333b5995eeb0268d327