### PR TITLE
Add --top option for search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ When you run `simgrep "your query" ./path/to/search`:
     *   Performs semantic similarity search using an in-memory USearch index.
     *   Outputs results showing the relevant file, similarity score, and the text chunk (`--output show`, default).
     *   Lists unique file paths containing matches (`--output paths`).
+    *   Limit the number of matches returned with `--top N` (alias `--k`).
 
 ## Near Future Plans (Persistent Indexing - Phase 3)
 

--- a/simgrep/main.py
+++ b/simgrep/main.py
@@ -162,6 +162,12 @@ def search(
         help="Output mode. 'paths' mode lists unique, sorted file paths containing matches.",
         case_sensitive=False,
     ),
+    top: int = typer.Option(
+        DEFAULT_K_RESULTS,
+        "--top",
+        "--k",
+        help="Number of top results to return from the vector search.",
+    ),
     relative_paths: bool = typer.Option(
         False,
         "--relative-paths/--absolute-paths",  # Provides --no-relative-paths as well
@@ -225,7 +231,7 @@ def search(
                 vector_index=persistent_vector_index,
                 global_config=global_simgrep_config,
                 output_mode=output,
-                k_results=DEFAULT_K_RESULTS,  # Make this configurable later
+                k_results=top,
                 display_relative_paths=relative_paths,
                 # For persistent search, base_path_for_relativity might need to be CWD or a configured project root.
                 # For now, persistent search will show absolute paths if relative_paths is true but no base_path.
@@ -326,7 +332,7 @@ def search(
 
             except FileNotFoundError:
                 console.print(
-                    f"    [bold red]Error: File not found during processing loop: {file_path_item}. " "Skipping.[/bold red]"
+                    f"    [bold red]Error: File not found during processing loop: {file_path_item}. Skipping.[/bold red]"
                 )
                 files_skipped.append((file_path_item, "File not found during processing"))
             except RuntimeError as e:
@@ -334,7 +340,7 @@ def search(
                 files_skipped.append((file_path_item, str(e)))
             except ValueError as ve:
                 console.print(
-                    f"    [bold red]Error with chunking parameters for file '{file_path_item}': {ve}. " "Skipping.[/bold red]"
+                    f"    [bold red]Error with chunking parameters for file '{file_path_item}': {ve}. Skipping.[/bold red]"
                 )
                 files_skipped.append((file_path_item, str(ve)))
             except Exception as e:
@@ -436,11 +442,11 @@ def search(
                     f"Metric: {vector_index.metric}, DType: {str(vector_index.dtype)}"
                 )
 
-                console.print(f"  Searching index for top {DEFAULT_K_RESULTS} similar chunk(s)...")
+                console.print(f"  Searching index for top {top} similar chunk(s)...")
                 search_matches = search_inmemory_index(
                     index=vector_index,
                     query_embedding=query_embedding,
-                    k=DEFAULT_K_RESULTS,
+                    k=top,
                 )
 
                 if not search_matches:

--- a/tests/e2e/test_cli_persistent_e2e.py
+++ b/tests/e2e/test_cli_persistent_e2e.py
@@ -35,9 +35,7 @@ def run_simgrep_command(
     if env:
         console.print(f"[dim]Env overrides: {env}[/dim]")
 
-    result = subprocess.run(
-        command, capture_output=True, text=True, cwd=cwd, env=process_env
-    )
+    result = subprocess.run(command, capture_output=True, text=True, cwd=cwd, env=process_env)
 
     if result.stdout:
         console.print("[bold green]Stdout:[/bold green]")
@@ -49,9 +47,7 @@ def run_simgrep_command(
 
 
 @pytest.fixture
-def temp_simgrep_home(
-    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
-) -> Generator[pathlib.Path, None, None]:
+def temp_simgrep_home(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> Generator[pathlib.Path, None, None]:
     """
     Creates a temporary home directory for simgrep E2E tests.
     This fixture ensures that simgrep's configuration and data (like default project)
@@ -85,18 +81,12 @@ def sample_docs_dir_session(tmp_path_factory: pytest.TempPathFactory) -> pathlib
     """Creates a sample documents directory for the test session."""
     docs_dir = pathlib.Path(tmp_path_factory.mktemp("sample_docs_e2e"))
     (docs_dir / "doc1.txt").write_text("This is a document about apples and bananas.")
-    (docs_dir / "doc2.txt").write_text(
-        "Another document, this one mentions oranges and apples."
-    )
-    (docs_dir / "doc3.md").write_text(
-        "# Markdown Test\nThis is a test for markdown with apples."
-    )  # Test non-.txt
+    (docs_dir / "doc2.txt").write_text("Another document, this one mentions oranges and apples.")
+    (docs_dir / "doc3.md").write_text("# Markdown Test\nThis is a test for markdown with apples.")  # Test non-.txt
 
     subdir = docs_dir / "subdir"
     subdir.mkdir()
-    (subdir / "doc_sub.txt").write_text(
-        "A document in a subdirectory, also about bananas."
-    )
+    (subdir / "doc_sub.txt").write_text("A document in a subdirectory, also about bananas.")
     return docs_dir
 
 
@@ -112,38 +102,27 @@ class TestCliPersistentE2E:
         env_vars = {"HOME": str(temp_simgrep_home)}
 
         # 1. Index the sample documents
-        index_result = run_simgrep_command(
-            ["index", str(sample_docs_dir_session)], env=env_vars
-        )
+        index_result = run_simgrep_command(["index", str(sample_docs_dir_session)], env=env_vars)
         assert index_result.returncode == 0
         assert "Successfully indexed" in index_result.stdout
         assert "default project" in index_result.stdout
         # Check that .txt files were indexed (default pattern)
-        assert (
-            "3 files processed" in index_result.stdout
-        )  # doc1.txt, doc2.txt, doc_sub.txt
+        assert "3 files processed" in index_result.stdout  # doc1.txt, doc2.txt, doc_sub.txt
         assert "0 errors encountered" in index_result.stdout
 
         # 2. Search the persistent index (show mode - default)
         search_result = run_simgrep_command(["search", "apples"], env=env_vars)
         assert search_result.returncode == 0
-        assert (
-            "Searching for: 'apples' in default persistent index"
-            in search_result.stdout
-        )
+        assert "Searching for: 'apples' in default persistent index" in search_result.stdout
         assert "doc1.txt" in search_result.stdout
         assert "doc2.txt" in search_result.stdout
-        assert (
-            "markdown" not in search_result.stdout.lower()
-        )  # doc3.md should not be indexed by default
+        assert "markdown" not in search_result.stdout.lower()  # doc3.md should not be indexed by default
 
         # Check for a term present in a .txt file in a subdirectory
         search_banana_result = run_simgrep_command(["search", "bananas"], env=env_vars)
         assert search_banana_result.returncode == 0
         assert "doc1.txt" in search_banana_result.stdout
-        assert (
-            str(pathlib.Path("subdir") / "doc_sub.txt") in search_banana_result.stdout
-        )  # Check subpath
+        assert str(pathlib.Path("subdir") / "doc_sub.txt") in search_banana_result.stdout  # Check subpath
 
     def test_index_and_search_persistent_paths_mode(
         self, temp_simgrep_home: pathlib.Path, sample_docs_dir_session: pathlib.Path
@@ -151,14 +130,10 @@ class TestCliPersistentE2E:
         env_vars = {"HOME": str(temp_simgrep_home)}
 
         # 1. Index (assuming it's clean or wiped by indexer logic)
-        run_simgrep_command(
-            ["index", str(sample_docs_dir_session)], env=env_vars
-        )  # Ensure index is fresh
+        run_simgrep_command(["index", str(sample_docs_dir_session)], env=env_vars)  # Ensure index is fresh
 
         # 2. Search with --output paths
-        search_result = run_simgrep_command(
-            ["search", "apples", "--output", "paths"], env=env_vars
-        )
+        search_result = run_simgrep_command(["search", "apples", "--output", "paths"], env=env_vars)
         assert search_result.returncode == 0
 
         # Output should be a list of paths, sorted.
@@ -167,21 +142,14 @@ class TestCliPersistentE2E:
         assert "doc1.txt" in search_result.stdout
         assert "doc2.txt" in search_result.stdout
 
-    def test_search_persistent_no_matches(
-        self, temp_simgrep_home: pathlib.Path, sample_docs_dir_session: pathlib.Path
-    ) -> None:
+    def test_search_persistent_no_matches(self, temp_simgrep_home: pathlib.Path, sample_docs_dir_session: pathlib.Path) -> None:
         env_vars = {"HOME": str(temp_simgrep_home)}
         run_simgrep_command(["index", str(sample_docs_dir_session)], env=env_vars)
 
-        search_result = run_simgrep_command(
-            ["search", "nonexistentqueryxyz"], env=env_vars
-        )
+        search_result = run_simgrep_command(["search", "nonexistentqueryxyz"], env=env_vars)
         assert search_result.returncode == 0  # Should exit cleanly
         # Accept either 'No relevant chunks found' or only low scores in output
-        assert (
-            "No relevant chunks found" in search_result.stdout
-            or "Score:" in search_result.stdout
-        )
+        assert "No relevant chunks found" in search_result.stdout or "Score:" in search_result.stdout
 
     def test_status_after_index(
         self,
@@ -191,13 +159,7 @@ class TestCliPersistentE2E:
         env_vars = {"HOME": str(temp_simgrep_home)}
         run_simgrep_command(["index", str(sample_docs_dir_session)], env=env_vars)
 
-        db_file = (
-            temp_simgrep_home
-            / ".config"
-            / "simgrep"
-            / "default_project"
-            / "metadata.duckdb"
-        )
+        db_file = temp_simgrep_home / ".config" / "simgrep" / "default_project" / "metadata.duckdb"
         conn = duckdb.connect(str(db_file))
         files_count = conn.execute("SELECT COUNT(*) FROM indexed_files;").fetchone()[0]
         chunks_count = conn.execute("SELECT COUNT(*) FROM text_chunks;").fetchone()[0]
@@ -214,15 +176,11 @@ class TestCliPersistentE2E:
         assert status_result.returncode == 1
         assert "Default persistent index not found" in status_result.stdout
 
-        search_paths_result = run_simgrep_command(
-            ["search", "nonexistentqueryxyz", "--output", "paths"], env=env_vars
-        )
+        search_paths_result = run_simgrep_command(["search", "nonexistentqueryxyz", "--output", "paths"], env=env_vars)
         assert search_paths_result.returncode == 0
         assert "No matching files found." in search_paths_result.stdout
 
-    def test_search_persistent_index_not_exists(
-        self, temp_simgrep_home: pathlib.Path
-    ) -> None:
+    def test_search_persistent_index_not_exists(self, temp_simgrep_home: pathlib.Path) -> None:
         env_vars = {"HOME": str(temp_simgrep_home)}
         # Do not run index command
         search_result = run_simgrep_command(["search", "anything"], env=env_vars)
@@ -230,9 +188,7 @@ class TestCliPersistentE2E:
         assert "Default persistent index not found" in search_result.stdout
         assert "Please run 'simgrep index <path>' first" in search_result.stdout
 
-    def test_index_empty_directory(
-        self, temp_simgrep_home: pathlib.Path, tmp_path: pathlib.Path
-    ) -> None:
+    def test_index_empty_directory(self, temp_simgrep_home: pathlib.Path, tmp_path: pathlib.Path) -> None:
         env_vars = {"HOME": str(temp_simgrep_home)}
         empty_dir = tmp_path / "empty_docs_for_e2e"
         empty_dir.mkdir()
@@ -240,9 +196,7 @@ class TestCliPersistentE2E:
         index_result = run_simgrep_command(["index", str(empty_dir)], env=env_vars)
         assert index_result.returncode == 0
         assert "No files found to index" in index_result.stdout
-        assert (
-            "0 files processed" in index_result.stdout
-        )  # Or similar message indicating no work done
+        assert "0 files processed" in index_result.stdout  # Or similar message indicating no work done
 
         # Search should find nothing or report missing index
         search_result = run_simgrep_command(["search", "anything"], env=env_vars)
@@ -258,21 +212,27 @@ class TestCliPersistentE2E:
     ) -> None:
         env_vars = {"HOME": str(temp_simgrep_home)}
 
-        index_result = run_simgrep_command(
-            ["index", str(sample_docs_dir_session)], env=env_vars
-        )
+        index_result = run_simgrep_command(["index", str(sample_docs_dir_session)], env=env_vars)
         assert index_result.returncode == 0
         # doc3.md should be ignored by default patterns
-        assert (
-            "3 files processed" in index_result.stdout
-        )  # doc1.txt, doc2.txt, subdir/doc_sub.txt
+        assert "3 files processed" in index_result.stdout  # doc1.txt, doc2.txt, subdir/doc_sub.txt
 
-        search_result = run_simgrep_command(
-            ["search", "markdown"], env=env_vars
-        )  # "markdown" is in doc3.md
+        search_result = run_simgrep_command(["search", "markdown"], env=env_vars)  # "markdown" is in doc3.md
         assert search_result.returncode == 0
         # Accept either 'No relevant chunks found' or only low scores in output
-        assert (
-            "No relevant chunks found" in search_result.stdout
-            or "Score:" in search_result.stdout
-        )
+        assert "No relevant chunks found" in search_result.stdout or "Score:" in search_result.stdout
+
+    def test_search_top_option_limits_results(
+        self, temp_simgrep_home: pathlib.Path, sample_docs_dir_session: pathlib.Path
+    ) -> None:
+        env_vars = {"HOME": str(temp_simgrep_home)}
+
+        run_simgrep_command(["index", str(sample_docs_dir_session)], env=env_vars)
+
+        top1_result = run_simgrep_command(["search", "apples", "--top", "1"], env=env_vars)
+        assert top1_result.returncode == 0
+        assert top1_result.stdout.count("File:") == 1
+
+        top2_result = run_simgrep_command(["search", "apples", "--top", "2"], env=env_vars)
+        assert top2_result.returncode == 0
+        assert top2_result.stdout.count("File:") >= 2

--- a/tests/unit/test_search_inmemory_top.py
+++ b/tests/unit/test_search_inmemory_top.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pytest
+import usearch.index
+
+from simgrep.vector_store import search_inmemory_index
+
+pytest.importorskip("usearch.index")
+
+
+@pytest.fixture
+def simple_usearch_index() -> usearch.index.Index:
+    index = usearch.index.Index(ndim=3, metric="cos", dtype="f32")
+    keys = np.array([1, 2, 3], dtype=np.int64)
+    vectors = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], dtype=np.float32)
+    index.add(keys=keys, vectors=vectors)
+    return index
+
+
+def test_search_inmemory_respects_k(simple_usearch_index: usearch.index.Index) -> None:
+    query = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+    result_one = search_inmemory_index(simple_usearch_index, query, k=1)
+    assert len(result_one) == 1
+
+    result_two = search_inmemory_index(simple_usearch_index, query, k=2)
+    assert len(result_two) == 2


### PR DESCRIPTION
## Summary
- allow customizing number of search results with `--top/--k`
- wire the option through persistent and ephemeral search paths
- document new option in README
- test that CLI and `search_inmemory_index` respect the value

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6841ed1a64e88333a539db5bb5dee14e