### PR TITLE
Add pattern option for search CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ When you run `simgrep "your query" ./path/to/search`:
 
 *   **Searches:**
     *   A single file.
-    *   Recursively through a directory (currently processes `.txt` files).
+    *   Recursively through a directory (files matching `--pattern`; defaults to `*.txt`).
 *   **Processing:**
     *   Extracts text from files using `unstructured`.
     *   Chunks text using token-based strategies (configurable model, size, overlap - defaults used for now).
@@ -24,6 +24,20 @@ When you run `simgrep "your query" ./path/to/search`:
     *   Performs semantic similarity search using an in-memory USearch index.
     *   Outputs results showing the relevant file, similarity score, and the text chunk (`--output show`, default).
     *   Lists unique file paths containing matches (`--output paths`).
+
+### Examples
+
+Search only markdown files:
+
+```bash
+simgrep search "apples" docs --pattern "*.md"
+```
+
+Search both text and markdown files:
+
+```bash
+simgrep search "apples" docs --pattern "*.txt" --pattern "*.md"
+```
 
 ## Near Future Plans (Persistent Indexing - Phase 3)
 

--- a/simgrep/main.py
+++ b/simgrep/main.py
@@ -42,6 +42,7 @@ try:
         load_tokenizer,
     )
     from .searcher import perform_persistent_search  # Added perform_persistent_search
+    from .utils import gather_files_to_process
     from .vector_store import (
         VectorStoreError,  # Added VectorStoreError
         create_inmemory_index,
@@ -81,6 +82,7 @@ except ImportError:
             load_tokenizer,
         )
         from simgrep.searcher import perform_persistent_search  # Added
+        from simgrep.utils import gather_files_to_process
         from simgrep.vector_store import (  # Added
             VectorStoreError,
             create_inmemory_index,
@@ -155,6 +157,12 @@ def search(
         resolve_path=True,
         help="The path to a text file or directory for ephemeral search. If omitted, searches the default persistent index.",
     ),
+    patterns: Optional[List[str]] = typer.Option(
+        None,
+        "--pattern",
+        "-p",
+        help="Glob pattern(s) for files when searching directories. Can be used multiple times. Defaults to '*.txt'.",
+    ),
     output: OutputMode = typer.Option(
         OutputMode.show,  # Default output mode
         "--output",
@@ -172,9 +180,11 @@ def search(
         ),
     ),
 ) -> None:
-    """
-    Searches for a query within a specified text file or files in a directory (ephemeral search),
-    or against the default persistent index if path_to_search is omitted.
+    """Searches for a query within files.
+
+    If ``path_to_search`` is a directory, files are discovered using the given
+    ``patterns`` (default ``['*.txt']``). If ``path_to_search`` is omitted the
+    persistent index is searched instead.
     """
     global_simgrep_config: SimgrepConfig = load_or_create_global_config()  # Load config early
 
@@ -266,17 +276,17 @@ def search(
         files_to_process: List[Path] = []
         files_skipped: List[Tuple[Path, str]] = []
 
+        search_patterns = patterns or ["*.txt"]
+        files_to_process = gather_files_to_process(path_to_search, search_patterns)
+
         if path_to_search.is_file():
-            files_to_process.append(path_to_search)
             console.print(f"Processing single file: [green]{path_to_search}[/green]")
-        elif path_to_search.is_dir():
-            console.print(f"Scanning directory: [green]{path_to_search}[/green] for processable files...")
-            discovered_files_generator = path_to_search.rglob("*.txt")
-            files_to_process = list(discovered_files_generator)
+        else:
+            console.print(f"Scanning directory: [green]{path_to_search}[/green] for files matching: {search_patterns}...")
             if not files_to_process:
-                console.print(f"[yellow]No '.txt' files found in directory: {path_to_search}[/yellow]")
+                console.print(f"[yellow]No files found in directory {path_to_search} with patterns {search_patterns}[/yellow]")
             else:
-                console.print(f"Found {len(files_to_process)} '.txt' file(s) to process.")
+                console.print(f"Found {len(files_to_process)} file(s) to process.")
 
         if not files_to_process:
             console.print("No files selected for processing. Exiting.")
@@ -326,7 +336,7 @@ def search(
 
             except FileNotFoundError:
                 console.print(
-                    f"    [bold red]Error: File not found during processing loop: {file_path_item}. " "Skipping.[/bold red]"
+                    f"    [bold red]Error: File not found during processing loop: {file_path_item}. Skipping.[/bold red]"
                 )
                 files_skipped.append((file_path_item, "File not found during processing"))
             except RuntimeError as e:
@@ -334,7 +344,7 @@ def search(
                 files_skipped.append((file_path_item, str(e)))
             except ValueError as ve:
                 console.print(
-                    f"    [bold red]Error with chunking parameters for file '{file_path_item}': {ve}. " "Skipping.[/bold red]"
+                    f"    [bold red]Error with chunking parameters for file '{file_path_item}': {ve}. Skipping.[/bold red]"
                 )
                 files_skipped.append((file_path_item, str(ve)))
             except Exception as e:

--- a/simgrep/utils.py
+++ b/simgrep/utils.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from typing import List
+
+
+def gather_files_to_process(path: Path, patterns: List[str]) -> List[Path]:
+    """Return files in ``path`` matching any of the glob ``patterns``."""
+    if path.is_file():
+        return [path]
+
+    found: set[Path] = set()
+    for pattern in patterns:
+        for p in path.rglob(pattern):
+            if p.is_file():
+                found.add(p.resolve())
+
+    return sorted(found)

--- a/tests/unit/test_main_patterns.py
+++ b/tests/unit/test_main_patterns.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from simgrep.utils import gather_files_to_process
+
+
+class TestGatherFilesToProcess:
+    def test_single_pattern(self, tmp_path: Path) -> None:
+        (tmp_path / "a.txt").write_text("A")
+        (tmp_path / "b.md").write_text("B")
+        result = gather_files_to_process(tmp_path, ["*.txt"])
+        assert result == [(tmp_path / "a.txt").resolve()]
+
+    def test_multiple_patterns(self, tmp_path: Path) -> None:
+        file_txt = tmp_path / "a.txt"
+        file_md = tmp_path / "b.md"
+        file_csv = tmp_path / "c.csv"
+        file_txt.write_text("A")
+        file_md.write_text("B")
+        file_csv.write_text("C")
+        result = gather_files_to_process(tmp_path, ["*.txt", "*.md"])
+        assert set(result) == {file_txt.resolve(), file_md.resolve()}


### PR DESCRIPTION
## Summary
- add `--pattern` option to CLI
- search uses provided patterns
- document new option with examples
- introduce helper for file discovery
- test pattern filtering

## Testing
- `ruff check .`
- `pytest tests/unit/test_main_patterns.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6841ed167bd88333b60d83f995d5462f