### PR TITLE
Use console for format_paths warning

### DIFF
--- a/simgrep/formatter.py
+++ b/simgrep/formatter.py
@@ -1,6 +1,7 @@
-import sys
 from pathlib import Path
 from typing import List, Optional
+
+from rich.console import Console
 
 
 def format_show_basic(file_path: Path, chunk_text: str, score: float) -> str:
@@ -22,7 +23,9 @@ def format_show_basic(file_path: Path, chunk_text: str, score: float) -> str:
 def format_paths(
     file_paths: List[Path],
     use_relative: bool,
-    base_path: Optional[Path]
+    base_path: Optional[Path],
+    *,
+    console: Optional[Console] = None,
 ) -> str:
     """
     Formats a list of file paths for display. Paths are unique and sorted.
@@ -42,15 +45,18 @@ def format_paths(
     # ensure all paths are absolute, then unique and sorted.
     # paths from retrieve_chunk_for_display should already be absolute and resolved.
     unique_absolute_paths = sorted(list(set(p.resolve() for p in file_paths)))
-    
+
     output_paths_str_list: List[str] = []
+
+    if console is None:
+        console = Console()
 
     if use_relative:
         if base_path is None:
-            print(
+            console.print(
                 "Warning (simgrep internal): base_path was not provided to format_paths "
                 "when use_relative was True. Defaulting to absolute paths.",
-                file=sys.stderr
+                style="yellow",
             )
             # fallback to absolute paths for this call
             for p_abs in unique_absolute_paths:
@@ -65,8 +71,8 @@ def format_paths(
                     # fallback to absolute path if it cannot be made relative
                     # (e.g., different drive on windows, or not a subpath)
                     output_paths_str_list.append(str(p_abs.resolve()))
-    else: # use_relative is false
+    else:  # use_relative is false
         for p_abs in unique_absolute_paths:
             output_paths_str_list.append(str(p_abs.resolve()))
-    
+
     return "\n".join(output_paths_str_list)

--- a/simgrep/main.py
+++ b/simgrep/main.py
@@ -213,7 +213,14 @@ def search(
                 console.print("[yellow]Warning: The persistent vector index is empty. No search can be performed.[/yellow]")
                 # Output "no results" based on mode
                 if output == OutputMode.paths:
-                    console.print(format_paths(file_paths=[], use_relative=False, base_path=None))
+                    console.print(
+                        format_paths(
+                            file_paths=[],
+                            use_relative=False,
+                            base_path=None,
+                            console=console,
+                        )
+                    )
                 else:  # show
                     console.print("  No relevant chunks found in the persistent index.")
                 raise typer.Exit()
@@ -464,7 +471,12 @@ def search(
         if not search_matches:
             if output == OutputMode.paths:
                 console.print(
-                    format_paths(file_paths=[], use_relative=False, base_path=None)
+                    format_paths(
+                        file_paths=[],
+                        use_relative=False,
+                        base_path=None,
+                        console=console,
+                    )
                 )  # Handles "No matching files found."
             else:  # OutputMode.show or other future modes that might show "no results"
                 console.print("  No relevant chunks found for your query in the processed file(s).")
@@ -492,6 +504,7 @@ def search(
                     file_paths=paths_from_matches,
                     use_relative=actual_use_relative,
                     base_path=current_base_path_for_relativity,
+                    console=console,
                 )
                 if output_string:
                     console.print(output_string)

--- a/simgrep/searcher.py
+++ b/simgrep/searcher.py
@@ -32,17 +32,11 @@ def perform_persistent_search(
     Orchestrates the search process against a pre-existing, loaded persistent index.
     """
     embedding_model_name = global_config.default_embedding_model_name
-    console.print(
-        f"  Embedding query: '[italic blue]{query_text}[/italic blue]' using model '{embedding_model_name}'..."
-    )
+    console.print(f"  Embedding query: '[italic blue]{query_text}[/italic blue]' using model '{embedding_model_name}'...")
     try:
-        query_embedding = generate_embeddings(
-            texts=[query_text], model_name=embedding_model_name
-        )
+        query_embedding = generate_embeddings(texts=[query_text], model_name=embedding_model_name)
     except RuntimeError as e:
-        console.print(
-            f"[bold red]Failed to generate query embedding:[/bold red]\n  {e}"
-        )
+        console.print(f"[bold red]Failed to generate query embedding:[/bold red]\n  {e}")
         raise  # re-raise for main.py to catch and exit
 
     console.print(f"  Searching persistent index for top {k_results} similar chunks...")
@@ -55,9 +49,7 @@ def perform_persistent_search(
         raise  # re-raise
 
     # Filter by min_score
-    filtered_matches = [
-        (label, score) for (label, score) in search_matches if score >= min_score
-    ]
+    filtered_matches = [(label, score) for (label, score) in search_matches if score >= min_score]
 
     if not filtered_matches:
         if output_mode == OutputMode.paths:
@@ -67,6 +59,7 @@ def perform_persistent_search(
                     file_paths=[],
                     use_relative=display_relative_paths,
                     base_path=base_path_for_relativity,
+                    console=console,
                 )
             )
         else:  # outputmode.show
@@ -75,14 +68,10 @@ def perform_persistent_search(
 
     # process and format results
     if output_mode == OutputMode.show:
-        console.print(
-            f"\n[bold cyan]Search Results (Top {len(filtered_matches)} from persistent index):[/bold cyan]"
-        )
+        console.print(f"\n[bold cyan]Search Results (Top {len(filtered_matches)} from persistent index):[/bold cyan]")
         for matched_usearch_label, similarity_score in filtered_matches:
             try:
-                retrieved_details = retrieve_chunk_details_persistent(
-                    db_conn, matched_usearch_label
-                )
+                retrieved_details = retrieve_chunk_details_persistent(db_conn, matched_usearch_label)
             except MetadataDBError as e:
                 console.print(
                     f"[yellow]Warning: Database error retrieving details for chunk label {matched_usearch_label}: {e}[/yellow]"
@@ -107,9 +96,7 @@ def perform_persistent_search(
         unique_paths_seen = set()  # to ensure uniqueness before format_paths
         for matched_usearch_label, _similarity_score in filtered_matches:
             try:
-                retrieved_details = retrieve_chunk_details_persistent(
-                    db_conn, matched_usearch_label
-                )
+                retrieved_details = retrieve_chunk_details_persistent(db_conn, matched_usearch_label)
             except MetadataDBError as e:
                 console.print(
                     f"[yellow]Warning: Database error retrieving path for chunk label {matched_usearch_label}: {e}[/yellow]"
@@ -122,14 +109,13 @@ def perform_persistent_search(
                     paths_from_matches.append(file_path_obj)
                     unique_paths_seen.add(file_path_obj)
             else:
-                console.print(
-                    f"[yellow]Warning: Could not retrieve path for chunk label {matched_usearch_label}.[/yellow]"
-                )
+                console.print(f"[yellow]Warning: Could not retrieve path for chunk label {matched_usearch_label}.[/yellow]")
 
         output_string = format_paths(
             file_paths=paths_from_matches,  # already unique
             use_relative=display_relative_paths,
             base_path=base_path_for_relativity,
+            console=console,
         )
         # format_paths itself handles "no matching files found." if paths_from_matches is empty.
         console.print(output_string)

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from rich.console import Console
+
 import pytest
 
 from simgrep.formatter import format_paths
@@ -50,9 +52,10 @@ class TestFormatPaths:
         file1.write_text("1")
         file2.write_text("2")
 
-        result = format_paths([file1, file2], use_relative=True, base_path=None)
+        test_console = Console()
+        result = format_paths([file1, file2], use_relative=True, base_path=None, console=test_console)
         captured = capsys.readouterr()
-        assert "base_path was not provided to format_paths" in captured.err
+        assert "base_path was not provided to format_paths" in captured.out
 
         expected = "\n".join(
             sorted(


### PR DESCRIPTION
## Summary
- allow passing a console to `format_paths`
- show warnings via console
- plumb console usage through main and searcher modules
- test console warnings

## Testing
- `uv run ruff check simgrep tests`
- `uv run pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_6841ed1230948333af0bd9f3759bf9e3