### PR TITLE
Add confirmation prompt when indexing

### DIFF
--- a/simgrep/main.py
+++ b/simgrep/main.py
@@ -541,7 +541,10 @@ def index(
     """
     console.print(f"Starting indexing for path: [green]{path_to_index}[/green]")
     console.print("[bold yellow]Warning: This will wipe and rebuild the default project's index.[/bold yellow]")
-    # Future: typer.confirm("Are you sure you want to wipe and rebuild the default project index?", abort=True)
+    typer.confirm(
+        "Are you sure you want to wipe and rebuild the default project index?",
+        abort=True,
+    )
 
     try:
         global_simgrep_config: SimgrepConfig = load_or_create_global_config()

--- a/tests/e2e/test_cli_persistent_e2e.py
+++ b/tests/e2e/test_cli_persistent_e2e.py
@@ -21,6 +21,7 @@ def run_simgrep_command(
     args: List[str],
     cwd: Optional[pathlib.Path] = None,
     env: Optional[Dict[str, str]] = None,
+    input: Optional[str] = None,
 ) -> subprocess.CompletedProcess:
     """Helper function to run simgrep CLI commands."""
     command = [sys.executable, "-m", "simgrep.main"] + args
@@ -36,7 +37,12 @@ def run_simgrep_command(
         console.print(f"[dim]Env overrides: {env}[/dim]")
 
     result = subprocess.run(
-        command, capture_output=True, text=True, cwd=cwd, env=process_env
+        command,
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        env=process_env,
+        input=input,
     )
 
     if result.stdout:
@@ -49,9 +55,7 @@ def run_simgrep_command(
 
 
 @pytest.fixture
-def temp_simgrep_home(
-    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
-) -> Generator[pathlib.Path, None, None]:
+def temp_simgrep_home(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> Generator[pathlib.Path, None, None]:
     """
     Creates a temporary home directory for simgrep E2E tests.
     This fixture ensures that simgrep's configuration and data (like default project)
@@ -85,18 +89,12 @@ def sample_docs_dir_session(tmp_path_factory: pytest.TempPathFactory) -> pathlib
     """Creates a sample documents directory for the test session."""
     docs_dir = pathlib.Path(tmp_path_factory.mktemp("sample_docs_e2e"))
     (docs_dir / "doc1.txt").write_text("This is a document about apples and bananas.")
-    (docs_dir / "doc2.txt").write_text(
-        "Another document, this one mentions oranges and apples."
-    )
-    (docs_dir / "doc3.md").write_text(
-        "# Markdown Test\nThis is a test for markdown with apples."
-    )  # Test non-.txt
+    (docs_dir / "doc2.txt").write_text("Another document, this one mentions oranges and apples.")
+    (docs_dir / "doc3.md").write_text("# Markdown Test\nThis is a test for markdown with apples.")  # Test non-.txt
 
     subdir = docs_dir / "subdir"
     subdir.mkdir()
-    (subdir / "doc_sub.txt").write_text(
-        "A document in a subdirectory, also about bananas."
-    )
+    (subdir / "doc_sub.txt").write_text("A document in a subdirectory, also about bananas.")
     return docs_dir
 
 
@@ -113,37 +111,30 @@ class TestCliPersistentE2E:
 
         # 1. Index the sample documents
         index_result = run_simgrep_command(
-            ["index", str(sample_docs_dir_session)], env=env_vars
+            ["index", str(sample_docs_dir_session)],
+            env=env_vars,
+            input="y\n",
         )
         assert index_result.returncode == 0
         assert "Successfully indexed" in index_result.stdout
         assert "default project" in index_result.stdout
         # Check that .txt files were indexed (default pattern)
-        assert (
-            "3 files processed" in index_result.stdout
-        )  # doc1.txt, doc2.txt, doc_sub.txt
+        assert "3 files processed" in index_result.stdout  # doc1.txt, doc2.txt, doc_sub.txt
         assert "0 errors encountered" in index_result.stdout
 
         # 2. Search the persistent index (show mode - default)
         search_result = run_simgrep_command(["search", "apples"], env=env_vars)
         assert search_result.returncode == 0
-        assert (
-            "Searching for: 'apples' in default persistent index"
-            in search_result.stdout
-        )
+        assert "Searching for: 'apples' in default persistent index" in search_result.stdout
         assert "doc1.txt" in search_result.stdout
         assert "doc2.txt" in search_result.stdout
-        assert (
-            "markdown" not in search_result.stdout.lower()
-        )  # doc3.md should not be indexed by default
+        assert "markdown" not in search_result.stdout.lower()  # doc3.md should not be indexed by default
 
         # Check for a term present in a .txt file in a subdirectory
         search_banana_result = run_simgrep_command(["search", "bananas"], env=env_vars)
         assert search_banana_result.returncode == 0
         assert "doc1.txt" in search_banana_result.stdout
-        assert (
-            str(pathlib.Path("subdir") / "doc_sub.txt") in search_banana_result.stdout
-        )  # Check subpath
+        assert str(pathlib.Path("subdir") / "doc_sub.txt") in search_banana_result.stdout  # Check subpath
 
     def test_index_and_search_persistent_paths_mode(
         self, temp_simgrep_home: pathlib.Path, sample_docs_dir_session: pathlib.Path
@@ -152,13 +143,13 @@ class TestCliPersistentE2E:
 
         # 1. Index (assuming it's clean or wiped by indexer logic)
         run_simgrep_command(
-            ["index", str(sample_docs_dir_session)], env=env_vars
+            ["index", str(sample_docs_dir_session)],
+            env=env_vars,
+            input="y\n",
         )  # Ensure index is fresh
 
         # 2. Search with --output paths
-        search_result = run_simgrep_command(
-            ["search", "apples", "--output", "paths"], env=env_vars
-        )
+        search_result = run_simgrep_command(["search", "apples", "--output", "paths"], env=env_vars)
         assert search_result.returncode == 0
 
         # Output should be a list of paths, sorted.
@@ -167,21 +158,46 @@ class TestCliPersistentE2E:
         assert "doc1.txt" in search_result.stdout
         assert "doc2.txt" in search_result.stdout
 
-    def test_search_persistent_no_matches(
-        self, temp_simgrep_home: pathlib.Path, sample_docs_dir_session: pathlib.Path
-    ) -> None:
+    def test_search_persistent_no_matches(self, temp_simgrep_home: pathlib.Path, sample_docs_dir_session: pathlib.Path) -> None:
         env_vars = {"HOME": str(temp_simgrep_home)}
-        run_simgrep_command(["index", str(sample_docs_dir_session)], env=env_vars)
-
-        search_result = run_simgrep_command(
-            ["search", "nonexistentqueryxyz"], env=env_vars
+        run_simgrep_command(
+            ["index", str(sample_docs_dir_session)],
+            env=env_vars,
+            input="y\n",
         )
+
+        search_result = run_simgrep_command(["search", "nonexistentqueryxyz"], env=env_vars)
         assert search_result.returncode == 0  # Should exit cleanly
         # Accept either 'No relevant chunks found' or only low scores in output
-        assert (
-            "No relevant chunks found" in search_result.stdout
-            or "Score:" in search_result.stdout
+        assert "No relevant chunks found" in search_result.stdout or "Score:" in search_result.stdout
+
+    def test_index_prompt_decline_aborts(self, temp_simgrep_home: pathlib.Path, sample_docs_dir_session: pathlib.Path) -> None:
+        env_vars = {"HOME": str(temp_simgrep_home)}
+
+        # Create initial index
+        first_result = run_simgrep_command(
+            ["index", str(sample_docs_dir_session)],
+            env=env_vars,
+            input="y\n",
         )
+        assert first_result.returncode == 0
+
+        db_file = temp_simgrep_home / ".config" / "simgrep" / "default_project" / "metadata.duckdb"
+        index_file = temp_simgrep_home / ".config" / "simgrep" / "default_project" / "index.usearch"
+        db_mtime = db_file.stat().st_mtime
+        index_mtime = index_file.stat().st_mtime
+
+        # Attempt reindex but decline at prompt
+        decline_result = run_simgrep_command(
+            ["index", str(sample_docs_dir_session)],
+            env=env_vars,
+            input="n\n",
+        )
+        assert decline_result.returncode != 0
+        assert "Aborted" in decline_result.stderr or "Aborted" in decline_result.stdout
+
+        assert db_file.stat().st_mtime == db_mtime
+        assert index_file.stat().st_mtime == index_mtime
 
     def test_status_after_index(
         self,
@@ -189,15 +205,13 @@ class TestCliPersistentE2E:
         sample_docs_dir_session: pathlib.Path,
     ) -> None:
         env_vars = {"HOME": str(temp_simgrep_home)}
-        run_simgrep_command(["index", str(sample_docs_dir_session)], env=env_vars)
-
-        db_file = (
-            temp_simgrep_home
-            / ".config"
-            / "simgrep"
-            / "default_project"
-            / "metadata.duckdb"
+        run_simgrep_command(
+            ["index", str(sample_docs_dir_session)],
+            env=env_vars,
+            input="y\n",
         )
+
+        db_file = temp_simgrep_home / ".config" / "simgrep" / "default_project" / "metadata.duckdb"
         conn = duckdb.connect(str(db_file))
         files_count = conn.execute("SELECT COUNT(*) FROM indexed_files;").fetchone()[0]
         chunks_count = conn.execute("SELECT COUNT(*) FROM text_chunks;").fetchone()[0]
@@ -214,15 +228,11 @@ class TestCliPersistentE2E:
         assert status_result.returncode == 1
         assert "Default persistent index not found" in status_result.stdout
 
-        search_paths_result = run_simgrep_command(
-            ["search", "nonexistentqueryxyz", "--output", "paths"], env=env_vars
-        )
+        search_paths_result = run_simgrep_command(["search", "nonexistentqueryxyz", "--output", "paths"], env=env_vars)
         assert search_paths_result.returncode == 0
         assert "No matching files found." in search_paths_result.stdout
 
-    def test_search_persistent_index_not_exists(
-        self, temp_simgrep_home: pathlib.Path
-    ) -> None:
+    def test_search_persistent_index_not_exists(self, temp_simgrep_home: pathlib.Path) -> None:
         env_vars = {"HOME": str(temp_simgrep_home)}
         # Do not run index command
         search_result = run_simgrep_command(["search", "anything"], env=env_vars)
@@ -230,19 +240,19 @@ class TestCliPersistentE2E:
         assert "Default persistent index not found" in search_result.stdout
         assert "Please run 'simgrep index <path>' first" in search_result.stdout
 
-    def test_index_empty_directory(
-        self, temp_simgrep_home: pathlib.Path, tmp_path: pathlib.Path
-    ) -> None:
+    def test_index_empty_directory(self, temp_simgrep_home: pathlib.Path, tmp_path: pathlib.Path) -> None:
         env_vars = {"HOME": str(temp_simgrep_home)}
         empty_dir = tmp_path / "empty_docs_for_e2e"
         empty_dir.mkdir()
 
-        index_result = run_simgrep_command(["index", str(empty_dir)], env=env_vars)
+        index_result = run_simgrep_command(
+            ["index", str(empty_dir)],
+            env=env_vars,
+            input="y\n",
+        )
         assert index_result.returncode == 0
         assert "No files found to index" in index_result.stdout
-        assert (
-            "0 files processed" in index_result.stdout
-        )  # Or similar message indicating no work done
+        assert "0 files processed" in index_result.stdout  # Or similar message indicating no work done
 
         # Search should find nothing or report missing index
         search_result = run_simgrep_command(["search", "anything"], env=env_vars)
@@ -259,20 +269,15 @@ class TestCliPersistentE2E:
         env_vars = {"HOME": str(temp_simgrep_home)}
 
         index_result = run_simgrep_command(
-            ["index", str(sample_docs_dir_session)], env=env_vars
+            ["index", str(sample_docs_dir_session)],
+            env=env_vars,
+            input="y\n",
         )
         assert index_result.returncode == 0
         # doc3.md should be ignored by default patterns
-        assert (
-            "3 files processed" in index_result.stdout
-        )  # doc1.txt, doc2.txt, subdir/doc_sub.txt
+        assert "3 files processed" in index_result.stdout  # doc1.txt, doc2.txt, subdir/doc_sub.txt
 
-        search_result = run_simgrep_command(
-            ["search", "markdown"], env=env_vars
-        )  # "markdown" is in doc3.md
+        search_result = run_simgrep_command(["search", "markdown"], env=env_vars)  # "markdown" is in doc3.md
         assert search_result.returncode == 0
         # Accept either 'No relevant chunks found' or only low scores in output
-        assert (
-            "No relevant chunks found" in search_result.stdout
-            or "Score:" in search_result.stdout
-        )
+        assert "No relevant chunks found" in search_result.stdout or "Score:" in search_result.stdout

--- a/tests/integration/test_searcher_persistent_integration.py
+++ b/tests/integration/test_searcher_persistent_integration.py
@@ -10,8 +10,8 @@ pytest.importorskip("transformers")
 pytest.importorskip("sentence_transformers")
 pytest.importorskip("usearch.index")
 
-from simgrep.models import OutputMode, SimgrepConfig
-from simgrep.searcher import perform_persistent_search
+from simgrep.models import OutputMode, SimgrepConfig  # noqa: E402
+from simgrep.searcher import perform_persistent_search  # noqa: E402
 
 
 # Fixtures
@@ -26,9 +26,7 @@ def persistent_search_test_data_path(tmp_path_factory: pytest.TempPathFactory) -
     """Creates dummy files in a temporary directory for indexing in persistent search tests."""
     data_dir = tmp_path_factory.mktemp("persistent_search_data")
 
-    file1_content = (
-        "This file talks about simgrep and advanced information retrieval techniques."
-    )
+    file1_content = "This file talks about simgrep and advanced information retrieval techniques."
     (data_dir / "file1.txt").write_text(file1_content)
 
     file2_content = "Another document mentioning simgrep. Semantic search is powerful."
@@ -59,9 +57,7 @@ def default_simgrep_config_for_search_tests(
 def populated_persistent_index_for_searcher(
     persistent_search_test_data_path: Path,
     default_simgrep_config_for_search_tests: SimgrepConfig,
-) -> Generator[
-    Tuple[duckdb.DuckDBPyConnection, usearch.index.Index, SimgrepConfig], None, None
-]:
+) -> Generator[Tuple[duckdb.DuckDBPyConnection, usearch.index.Index, SimgrepConfig], None, None]:
     """
     Indexes dummy data and provides the DB connection, USearch index, and config for tests.
     This is session-scoped for efficiency as indexing can be slow.
@@ -102,9 +98,7 @@ def populated_persistent_index_for_searcher(
     vector_index = load_persistent_index(usearch_file)
 
     if vector_index is None:
-        pytest.fail(
-            "Failed to load persistent vector index in 'populated_persistent_index_for_searcher' fixture."
-        )
+        pytest.fail("Failed to load persistent vector index in 'populated_persistent_index_for_searcher' fixture.")
 
     yield db_conn, vector_index, cfg
 
@@ -118,9 +112,7 @@ def populated_persistent_index_for_searcher(
 class TestSearcherPersistentIntegration:
     def test_perform_persistent_search_show_mode_with_results(
         self,
-        populated_persistent_index_for_searcher: Tuple[
-            duckdb.DuckDBPyConnection, usearch.index.Index, SimgrepConfig
-        ],
+        populated_persistent_index_for_searcher: Tuple[duckdb.DuckDBPyConnection, usearch.index.Index, SimgrepConfig],
         test_console: Console,
         capsys: pytest.CaptureFixture,
         persistent_search_test_data_path: Path,
@@ -140,29 +132,19 @@ class TestSearcherPersistentIntegration:
         )
         captured = capsys.readouterr()
 
-        assert (
-            "Embedding query" in captured.out
-        ), "Initial 'Embedding query' print message missing."
+        assert "Embedding query" in captured.out, "Initial 'Embedding query' print message missing."
 
         # Robust check for file path
         expected_path_str = str(persistent_search_test_data_path / "file1.txt")
         cleaned_output = captured.out.replace("\n", "").replace("\r", "")
-        assert (
-            f"File: {expected_path_str}" in cleaned_output
-        ), f"Expected 'File: {expected_path_str}' to be among the results."
+        assert f"File: {expected_path_str}" in cleaned_output, f"Expected 'File: {expected_path_str}' to be among the results."
 
-        assert (
-            "Score:" in captured.out
-        ), "Output for 'show' mode should contain 'Score:'."
-        assert (
-            "Chunk:" in captured.out
-        ), "Output for 'show' mode should contain 'Chunk:'."
+        assert "Score:" in captured.out, "Output for 'show' mode should contain 'Score:'."
+        assert "Chunk:" in captured.out, "Output for 'show' mode should contain 'Chunk:'."
 
     def test_perform_persistent_search_paths_mode_with_results(
         self,
-        populated_persistent_index_for_searcher: Tuple[
-            duckdb.DuckDBPyConnection, usearch.index.Index, SimgrepConfig
-        ],
+        populated_persistent_index_for_searcher: Tuple[duckdb.DuckDBPyConnection, usearch.index.Index, SimgrepConfig],
         test_console: Console,
         capsys: pytest.CaptureFixture,
         persistent_search_test_data_path: Path,
@@ -181,22 +163,16 @@ class TestSearcherPersistentIntegration:
             min_score=0.25,  # Adjusted min_score
         )
         captured = capsys.readouterr()
-        assert (
-            "Embedding query" in captured.out
-        ), "Initial 'Embedding query' print message missing."
+        assert "Embedding query" in captured.out, "Initial 'Embedding query' print message missing."
 
         # Robust check for file path
         expected_path_str = str(persistent_search_test_data_path / "file2.txt")
         cleaned_output = captured.out.replace("\n", "").replace("\r", "")
-        assert (
-            expected_path_str in cleaned_output
-        ), f"Expected '{expected_path_str}' in paths output."
+        assert expected_path_str in cleaned_output, f"Expected '{expected_path_str}' in paths output."
 
     def test_perform_persistent_search_show_mode_no_results(
         self,
-        populated_persistent_index_for_searcher: Tuple[
-            duckdb.DuckDBPyConnection, usearch.index.Index, SimgrepConfig
-        ],
+        populated_persistent_index_for_searcher: Tuple[duckdb.DuckDBPyConnection, usearch.index.Index, SimgrepConfig],
         test_console: Console,
         capsys: pytest.CaptureFixture,
     ) -> None:
@@ -214,18 +190,12 @@ class TestSearcherPersistentIntegration:
             min_score=0.95,
         )
         captured = capsys.readouterr()
-        assert (
-            "Embedding query" in captured.out
-        ), "Initial 'Embedding query' print message missing."
-        assert (
-            "No relevant chunks found in the persistent index." in captured.out
-        ), "Expected 'no results' message for show mode."
+        assert "Embedding query" in captured.out, "Initial 'Embedding query' print message missing."
+        assert "No relevant chunks found in the persistent index." in captured.out, "Expected 'no results' message for show mode."
 
     def test_perform_persistent_search_paths_mode_no_results(
         self,
-        populated_persistent_index_for_searcher: Tuple[
-            duckdb.DuckDBPyConnection, usearch.index.Index, SimgrepConfig
-        ],
+        populated_persistent_index_for_searcher: Tuple[duckdb.DuckDBPyConnection, usearch.index.Index, SimgrepConfig],
         test_console: Console,
         capsys: pytest.CaptureFixture,
     ) -> None:
@@ -243,9 +213,5 @@ class TestSearcherPersistentIntegration:
             min_score=0.95,
         )
         captured = capsys.readouterr()
-        assert (
-            "Embedding query" in captured.out
-        ), "Initial 'Embedding query' print message missing."
-        assert (
-            "No matching files found." in captured.out
-        ), "Expected 'no results' message for paths mode."
+        assert "Embedding query" in captured.out, "Initial 'Embedding query' print message missing."
+        assert "No matching files found." in captured.out, "Expected 'no results' message for paths mode."

--- a/tests/unit/test_vector_store_persistent.py
+++ b/tests/unit/test_vector_store_persistent.py
@@ -8,7 +8,7 @@ import usearch.index
 pytest.importorskip("numpy")
 pytest.importorskip("usearch.index")
 
-from simgrep.vector_store import (
+from simgrep.vector_store import (  # noqa: E402
     VectorStoreError,
     load_persistent_index,
     save_persistent_index,
@@ -39,7 +39,6 @@ def empty_usearch_index() -> usearch.index.Index:
 
 
 class TestPersistentVectorStore:
-
     def test_save_and_load_persistent_index(
         self,
         sample_usearch_index: usearch.index.Index,
@@ -56,9 +55,7 @@ class TestPersistentVectorStore:
         assert persistent_index_path.parent.exists()  # directory was created
 
         # check that the temporary file is gone
-        temp_file_path = persistent_index_path.with_suffix(
-            persistent_index_path.suffix + ".tmp"
-        )
+        temp_file_path = persistent_index_path.with_suffix(persistent_index_path.suffix + ".tmp")
         assert not temp_file_path.exists()
 
         loaded_index = load_persistent_index(persistent_index_path)
@@ -66,20 +63,14 @@ class TestPersistentVectorStore:
         assert isinstance(loaded_index, usearch.index.Index)
         assert len(loaded_index) == len(sample_usearch_index)
         assert loaded_index.ndim == sample_usearch_index.ndim
-        assert (
-            str(loaded_index.metric).lower() == str(sample_usearch_index.metric).lower()
-        )  # noqa E501
-        assert (
-            str(loaded_index.dtype).lower() == str(sample_usearch_index.dtype).lower()
-        )
+        assert str(loaded_index.metric).lower() == str(sample_usearch_index.metric).lower()  # noqa E501
+        assert str(loaded_index.dtype).lower() == str(sample_usearch_index.dtype).lower()
 
         # verify keys are present (optional, but good for confidence)
         # note: usearch `index.keys()` might not be available or might be slow.
         # `index.get_key(internal_id)` or iterating `index` can get keys.
         # for simplicity, length check is often sufficient for basic save/load test.
-        original_keys = np.sort(
-            sample_usearch_index.keys
-        )  # get keys from original if api allows
+        original_keys = np.sort(sample_usearch_index.keys)  # get keys from original if api allows
         loaded_keys = np.sort(loaded_index.keys)
         assert np.array_equal(original_keys, loaded_keys)
 
@@ -97,9 +88,7 @@ class TestPersistentVectorStore:
         assert len(loaded_index) == 0
         assert loaded_index.ndim == empty_usearch_index.ndim
 
-    def test_load_persistent_index_non_existent_file(
-        self, persistent_index_path: pathlib.Path
-    ) -> None:
+    def test_load_persistent_index_non_existent_file(self, persistent_index_path: pathlib.Path) -> None:
         """test loading a non-existent index file returns none."""
         assert not persistent_index_path.exists()
         loaded_index = load_persistent_index(persistent_index_path)
@@ -114,9 +103,7 @@ class TestPersistentVectorStore:
         parent_dir_of_index_parent = persistent_index_path.parent.parent
         parent_dir_of_index_parent.mkdir(parents=True, exist_ok=True)
 
-        path_that_should_be_dir = (
-            persistent_index_path.parent
-        )  # e.g., .../persistent_indexes/
+        path_that_should_be_dir = persistent_index_path.parent  # e.g., .../persistent_indexes/
         path_that_should_be_dir.touch()  # create it as a file
 
         error_match = f"Could not create directory for USearch index at {str(path_that_should_be_dir)}"
@@ -130,9 +117,7 @@ class TestPersistentVectorStore:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """test that if os.replace fails, the temp file is cleaned up."""
-        temp_file_path = persistent_index_path.with_suffix(
-            persistent_index_path.suffix + ".tmp"
-        )
+        temp_file_path = persistent_index_path.with_suffix(persistent_index_path.suffix + ".tmp")
 
         def mock_os_replace(src: str, dst: str) -> None:
             # simulate that temp file was created before os.replace is called
@@ -143,9 +128,7 @@ class TestPersistentVectorStore:
 
         # the error message comes from the inner try-except block handling os.replace failure.
         # it should indicate failure to finalize the move to the persistent_index_path.
-        expected_error_message = (
-            f"Failed to finalize saving index to {str(persistent_index_path)}"
-        )
+        expected_error_message = f"Failed to finalize saving index to {str(persistent_index_path)}"
         with pytest.raises(VectorStoreError, match=expected_error_message):
             save_persistent_index(sample_usearch_index, persistent_index_path)
 
@@ -153,15 +136,11 @@ class TestPersistentVectorStore:
         assert not persistent_index_path.exists()
         assert not temp_file_path.exists()
 
-    def test_load_corrupted_index_file(
-        self, persistent_index_path: pathlib.Path
-    ) -> None:
+    def test_load_corrupted_index_file(self, persistent_index_path: pathlib.Path) -> None:
         """test loading a corrupted/invalid index file raises VectorStoreError."""
         persistent_index_path.parent.mkdir(parents=True, exist_ok=True)
         with open(persistent_index_path, "wb") as f:
             f.write(b"this is not a valid usearch index file content")
 
-        with pytest.raises(
-            VectorStoreError, match=f"Failed to load index from {persistent_index_path}"
-        ):
+        with pytest.raises(VectorStoreError, match=f"Failed to load index from {persistent_index_path}"):
             load_persistent_index(persistent_index_path)


### PR DESCRIPTION
## Summary
- add a `typer.confirm` prompt to the `index` CLI command
- extend the CLI helper to send stdin to subprocesses
- require `y` input when indexing in end-to-end tests
- add test ensuring declining the prompt aborts indexing
- mark late imports with `# noqa: E402` for linting

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6841ed1088e483338b5d0323f827658b