### PR TITLE
Add concurrent file indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ When you run `simgrep "your query" ./path/to/search`:
 
 *   **Searches:**
     *   A single file.
-    *   Recursively through a directory (currently processes `.txt` files).
+    *   Recursively through a directory (files matching `--pattern`; defaults to `*.txt`).
 *   **Processing:**
     *   Extracts text from files using `unstructured`.
     *   Chunks text using token-based strategies (configurable model, size, overlap - defaults used for now).
@@ -24,6 +24,21 @@ When you run `simgrep "your query" ./path/to/search`:
     *   Performs semantic similarity search using an in-memory USearch index.
     *   Outputs results showing the relevant file, similarity score, and the text chunk (`--output show`, default).
     *   Lists unique file paths containing matches (`--output paths`).
+    *   Limit the number of matches returned with `--top N` (alias `--k`).
+
+### Examples
+
+Search only markdown files:
+
+```bash
+simgrep search "apples" docs --pattern "*.md"
+```
+
+Search both text and markdown files:
+
+```bash
+simgrep search "apples" docs --pattern "*.txt" --pattern "*.md"
+```
 
 ## Near Future Plans (Persistent Indexing - Phase 3)
 

--- a/simgrep/formatter.py
+++ b/simgrep/formatter.py
@@ -1,6 +1,7 @@
-import sys
 from pathlib import Path
 from typing import List, Optional
+
+from rich.console import Console
 
 
 def format_show_basic(file_path: Path, chunk_text: str, score: float) -> str:
@@ -22,7 +23,9 @@ def format_show_basic(file_path: Path, chunk_text: str, score: float) -> str:
 def format_paths(
     file_paths: List[Path],
     use_relative: bool,
-    base_path: Optional[Path]
+    base_path: Optional[Path],
+    *,
+    console: Optional[Console] = None,
 ) -> str:
     """
     Formats a list of file paths for display. Paths are unique and sorted.
@@ -42,15 +45,18 @@ def format_paths(
     # ensure all paths are absolute, then unique and sorted.
     # paths from retrieve_chunk_for_display should already be absolute and resolved.
     unique_absolute_paths = sorted(list(set(p.resolve() for p in file_paths)))
-    
+
     output_paths_str_list: List[str] = []
+
+    if console is None:
+        console = Console()
 
     if use_relative:
         if base_path is None:
-            print(
+            console.print(
                 "Warning (simgrep internal): base_path was not provided to format_paths "
                 "when use_relative was True. Defaulting to absolute paths.",
-                file=sys.stderr
+                style="yellow",
             )
             # fallback to absolute paths for this call
             for p_abs in unique_absolute_paths:
@@ -65,8 +71,8 @@ def format_paths(
                     # fallback to absolute path if it cannot be made relative
                     # (e.g., different drive on windows, or not a subpath)
                     output_paths_str_list.append(str(p_abs.resolve()))
-    else: # use_relative is false
+    else:  # use_relative is false
         for p_abs in unique_absolute_paths:
             output_paths_str_list.append(str(p_abs.resolve()))
-    
+
     return "\n".join(output_paths_str_list)

--- a/simgrep/indexer.py
+++ b/simgrep/indexer.py
@@ -31,6 +31,8 @@ from .metadata_db import (
     batch_insert_text_chunks,
     clear_persistent_project_data,
     connect_persistent_db,
+    delete_file_records,
+    get_all_indexed_file_records,
     insert_indexed_file_record,
 )
 from .processor import (
@@ -156,7 +158,7 @@ class Indexer:
             raise IndexerError(f"Vector store preparation failed: {e}") from e
         except Exception as e_vs_unexpected:  # catch-all for unexpected vs errors
             self.usearch_index = None  # ensure it's none if setup failed
-            raise IndexerError("Unexpected error during vector store preparation: " f"{e_vs_unexpected}") from e_vs_unexpected
+            raise IndexerError(f"Unexpected error during vector store preparation: {e_vs_unexpected}") from e_vs_unexpected
 
         # final checks
         if self.usearch_index is None:
@@ -355,8 +357,8 @@ class Indexer:
                 found_files_set = set()
                 for pattern in self.config.file_scan_patterns:
                     for file_p in target_path.rglob(pattern):
-                        if file_p.is_file():  # ensure it's a file
-                            found_files_set.add(file_p.resolve())  # resolve for uniqueness
+                        if file_p.is_file():
+                            found_files_set.add(file_p.resolve())
                 files_to_process = sorted(list(found_files_set))
 
             if not files_to_process:
@@ -364,6 +366,24 @@ class Indexer:
                 # removed early return here to allow summary to print
             else:
                 self.console.print(f"Found {len(files_to_process)} file(s) to process.")
+
+            existing_records: Dict[pathlib.Path, Tuple[int, str]] = {}
+            if not wipe_existing:
+                try:
+                    assert self.db_conn is not None
+                    for fid, path_str, chash in get_all_indexed_file_records(self.db_conn):
+                        existing_records[pathlib.Path(path_str).resolve()] = (fid, chash)
+                except MetadataDBError as e:
+                    raise IndexerError(f"Failed to fetch existing file records: {e}") from e
+
+                existing_paths = set(existing_records.keys())
+                current_paths = set(p.resolve() for p in files_to_process)
+                deleted_paths = existing_paths - current_paths
+                for del_p in deleted_paths:
+                    fid, _ = existing_records[del_p]
+                    removed_labels = delete_file_records(self.db_conn, fid)
+                    if self.usearch_index is not None and removed_labels:
+                        self.usearch_index.remove(keys=np.array(removed_labels, dtype=np.int64))
 
             # rich progress bar setup
             progress_columns = [
@@ -383,10 +403,40 @@ class Indexer:
 
                 workers = max_workers if max_workers and max_workers > 0 else os.cpu_count() or 1
 
-                if workers <= 1 or len(files_to_process) <= 1:
-                    for file_p in files_to_process:
+                def submit_file(file_p: pathlib.Path) -> Optional[concurrent.futures.Future[Tuple[int, int]]]:
+                    nonlocal total_chunks_indexed, total_errors, total_files_processed
+                    resolved_fp = file_p.resolve()
+                    if not wipe_existing and resolved_fp in existing_records:
+                        try:
+                            current_hash = calculate_file_hash(resolved_fp)
+                        except FileNotFoundError:
+                            progress.update(
+                                file_processing_task,
+                                advance=1,
+                                description=f"Skipped (missing): {file_p.name}",
+                            )
+                            total_errors += 1
+                            return None
+
+                        stored_id, stored_hash = existing_records[resolved_fp]
+                        if current_hash == stored_hash:
+                            progress.update(
+                                file_processing_task,
+                                advance=1,
+                                description=f"Skipped (unchanged): {file_p.name}",
+                            )
+                            total_files_processed += 1
+                            return None
+
+                        with db_lock:
+                            removed_labels = delete_file_records(self.db_conn, stored_id)
+                        if self.usearch_index is not None and removed_labels:
+                            with index_lock:
+                                self.usearch_index.remove(keys=np.array(removed_labels, dtype=np.int64))
+
+                    if workers <= 1:
                         num_c, num_e = self._process_and_index_file(
-                            file_p,
+                            resolved_fp,
                             progress,
                             file_processing_task,
                             db_lock,
@@ -397,21 +447,25 @@ class Indexer:
                         total_errors += num_e
                         if num_e == 0 and num_c >= 0:
                             total_files_processed += 1
+                        return None
+
+                    return executor.submit(
+                        self._process_and_index_file,
+                        resolved_fp,
+                        progress,
+                        file_processing_task,
+                        db_lock,
+                        index_lock,
+                        label_lock,
+                    )
+
+                if workers <= 1 or len(files_to_process) <= 1:
+                    for file_p in files_to_process:
+                        submit_file(file_p)
                 else:
                     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
-                        futures = [
-                            executor.submit(
-                                self._process_and_index_file,
-                                file_p,
-                                progress,
-                                file_processing_task,
-                                db_lock,
-                                index_lock,
-                                label_lock,
-                            )
-                            for file_p in files_to_process
-                        ]
-                        for fut in concurrent.futures.as_completed(futures):
+                        futures = [submit_file(fp) for fp in files_to_process]
+                        for fut in concurrent.futures.as_completed([f for f in futures if f]):
                             num_c, num_e = fut.result()
                             total_chunks_indexed += num_c
                             total_errors += num_e

--- a/simgrep/searcher.py
+++ b/simgrep/searcher.py
@@ -32,17 +32,11 @@ def perform_persistent_search(
     Orchestrates the search process against a pre-existing, loaded persistent index.
     """
     embedding_model_name = global_config.default_embedding_model_name
-    console.print(
-        f"  Embedding query: '[italic blue]{query_text}[/italic blue]' using model '{embedding_model_name}'..."
-    )
+    console.print(f"  Embedding query: '[italic blue]{query_text}[/italic blue]' using model '{embedding_model_name}'...")
     try:
-        query_embedding = generate_embeddings(
-            texts=[query_text], model_name=embedding_model_name
-        )
+        query_embedding = generate_embeddings(texts=[query_text], model_name=embedding_model_name)
     except RuntimeError as e:
-        console.print(
-            f"[bold red]Failed to generate query embedding:[/bold red]\n  {e}"
-        )
+        console.print(f"[bold red]Failed to generate query embedding:[/bold red]\n  {e}")
         raise  # re-raise for main.py to catch and exit
 
     console.print(f"  Searching persistent index for top {k_results} similar chunks...")
@@ -55,9 +49,7 @@ def perform_persistent_search(
         raise  # re-raise
 
     # Filter by min_score
-    filtered_matches = [
-        (label, score) for (label, score) in search_matches if score >= min_score
-    ]
+    filtered_matches = [(label, score) for (label, score) in search_matches if score >= min_score]
 
     if not filtered_matches:
         if output_mode == OutputMode.paths:
@@ -67,6 +59,7 @@ def perform_persistent_search(
                     file_paths=[],
                     use_relative=display_relative_paths,
                     base_path=base_path_for_relativity,
+                    console=console,
                 )
             )
         else:  # outputmode.show
@@ -75,14 +68,10 @@ def perform_persistent_search(
 
     # process and format results
     if output_mode == OutputMode.show:
-        console.print(
-            f"\n[bold cyan]Search Results (Top {len(filtered_matches)} from persistent index):[/bold cyan]"
-        )
+        console.print(f"\n[bold cyan]Search Results (Top {len(filtered_matches)} from persistent index):[/bold cyan]")
         for matched_usearch_label, similarity_score in filtered_matches:
             try:
-                retrieved_details = retrieve_chunk_details_persistent(
-                    db_conn, matched_usearch_label
-                )
+                retrieved_details = retrieve_chunk_details_persistent(db_conn, matched_usearch_label)
             except MetadataDBError as e:
                 console.print(
                     f"[yellow]Warning: Database error retrieving details for chunk label {matched_usearch_label}: {e}[/yellow]"
@@ -107,9 +96,7 @@ def perform_persistent_search(
         unique_paths_seen = set()  # to ensure uniqueness before format_paths
         for matched_usearch_label, _similarity_score in filtered_matches:
             try:
-                retrieved_details = retrieve_chunk_details_persistent(
-                    db_conn, matched_usearch_label
-                )
+                retrieved_details = retrieve_chunk_details_persistent(db_conn, matched_usearch_label)
             except MetadataDBError as e:
                 console.print(
                     f"[yellow]Warning: Database error retrieving path for chunk label {matched_usearch_label}: {e}[/yellow]"
@@ -122,14 +109,13 @@ def perform_persistent_search(
                     paths_from_matches.append(file_path_obj)
                     unique_paths_seen.add(file_path_obj)
             else:
-                console.print(
-                    f"[yellow]Warning: Could not retrieve path for chunk label {matched_usearch_label}.[/yellow]"
-                )
+                console.print(f"[yellow]Warning: Could not retrieve path for chunk label {matched_usearch_label}.[/yellow]")
 
         output_string = format_paths(
             file_paths=paths_from_matches,  # already unique
             use_relative=display_relative_paths,
             base_path=base_path_for_relativity,
+            console=console,
         )
         # format_paths itself handles "no matching files found." if paths_from_matches is empty.
         console.print(output_string)

--- a/simgrep/utils.py
+++ b/simgrep/utils.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from typing import List
+
+
+def gather_files_to_process(path: Path, patterns: List[str]) -> List[Path]:
+    """Return files in ``path`` matching any of the glob ``patterns``."""
+    if path.is_file():
+        return [path]
+
+    found: set[Path] = set()
+    for pattern in patterns:
+        for p in path.rglob(pattern):
+            if p.is_file():
+                found.add(p.resolve())
+
+    return sorted(found)

--- a/tests/e2e/test_cli_persistent_e2e.py
+++ b/tests/e2e/test_cli_persistent_e2e.py
@@ -35,9 +35,7 @@ def run_simgrep_command(
     if env:
         console.print(f"[dim]Env overrides: {env}[/dim]")
 
-    result = subprocess.run(
-        command, capture_output=True, text=True, cwd=cwd, env=process_env
-    )
+    result = subprocess.run(command, capture_output=True, text=True, cwd=cwd, env=process_env)
 
     if result.stdout:
         console.print("[bold green]Stdout:[/bold green]")
@@ -49,9 +47,7 @@ def run_simgrep_command(
 
 
 @pytest.fixture
-def temp_simgrep_home(
-    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
-) -> Generator[pathlib.Path, None, None]:
+def temp_simgrep_home(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> Generator[pathlib.Path, None, None]:
     """
     Creates a temporary home directory for simgrep E2E tests.
     This fixture ensures that simgrep's configuration and data (like default project)
@@ -85,18 +81,12 @@ def sample_docs_dir_session(tmp_path_factory: pytest.TempPathFactory) -> pathlib
     """Creates a sample documents directory for the test session."""
     docs_dir = pathlib.Path(tmp_path_factory.mktemp("sample_docs_e2e"))
     (docs_dir / "doc1.txt").write_text("This is a document about apples and bananas.")
-    (docs_dir / "doc2.txt").write_text(
-        "Another document, this one mentions oranges and apples."
-    )
-    (docs_dir / "doc3.md").write_text(
-        "# Markdown Test\nThis is a test for markdown with apples."
-    )  # Test non-.txt
+    (docs_dir / "doc2.txt").write_text("Another document, this one mentions oranges and apples.")
+    (docs_dir / "doc3.md").write_text("# Markdown Test\nThis is a test for markdown with apples.")  # Test non-.txt
 
     subdir = docs_dir / "subdir"
     subdir.mkdir()
-    (subdir / "doc_sub.txt").write_text(
-        "A document in a subdirectory, also about bananas."
-    )
+    (subdir / "doc_sub.txt").write_text("A document in a subdirectory, also about bananas.")
     return docs_dir
 
 
@@ -112,38 +102,27 @@ class TestCliPersistentE2E:
         env_vars = {"HOME": str(temp_simgrep_home)}
 
         # 1. Index the sample documents
-        index_result = run_simgrep_command(
-            ["index", str(sample_docs_dir_session)], env=env_vars
-        )
+        index_result = run_simgrep_command(["index", str(sample_docs_dir_session)], env=env_vars)
         assert index_result.returncode == 0
         assert "Successfully indexed" in index_result.stdout
         assert "default project" in index_result.stdout
         # Check that .txt files were indexed (default pattern)
-        assert (
-            "3 files processed" in index_result.stdout
-        )  # doc1.txt, doc2.txt, doc_sub.txt
+        assert "3 files processed" in index_result.stdout  # doc1.txt, doc2.txt, doc_sub.txt
         assert "0 errors encountered" in index_result.stdout
 
         # 2. Search the persistent index (show mode - default)
         search_result = run_simgrep_command(["search", "apples"], env=env_vars)
         assert search_result.returncode == 0
-        assert (
-            "Searching for: 'apples' in default persistent index"
-            in search_result.stdout
-        )
+        assert "Searching for: 'apples' in default persistent index" in search_result.stdout
         assert "doc1.txt" in search_result.stdout
         assert "doc2.txt" in search_result.stdout
-        assert (
-            "markdown" not in search_result.stdout.lower()
-        )  # doc3.md should not be indexed by default
+        assert "markdown" not in search_result.stdout.lower()  # doc3.md should not be indexed by default
 
         # Check for a term present in a .txt file in a subdirectory
         search_banana_result = run_simgrep_command(["search", "bananas"], env=env_vars)
         assert search_banana_result.returncode == 0
         assert "doc1.txt" in search_banana_result.stdout
-        assert (
-            str(pathlib.Path("subdir") / "doc_sub.txt") in search_banana_result.stdout
-        )  # Check subpath
+        assert str(pathlib.Path("subdir") / "doc_sub.txt") in search_banana_result.stdout  # Check subpath
 
     def test_index_and_search_persistent_paths_mode(
         self, temp_simgrep_home: pathlib.Path, sample_docs_dir_session: pathlib.Path
@@ -151,14 +130,10 @@ class TestCliPersistentE2E:
         env_vars = {"HOME": str(temp_simgrep_home)}
 
         # 1. Index (assuming it's clean or wiped by indexer logic)
-        run_simgrep_command(
-            ["index", str(sample_docs_dir_session)], env=env_vars
-        )  # Ensure index is fresh
+        run_simgrep_command(["index", str(sample_docs_dir_session)], env=env_vars)  # Ensure index is fresh
 
         # 2. Search with --output paths
-        search_result = run_simgrep_command(
-            ["search", "apples", "--output", "paths"], env=env_vars
-        )
+        search_result = run_simgrep_command(["search", "apples", "--output", "paths"], env=env_vars)
         assert search_result.returncode == 0
 
         # Output should be a list of paths, sorted.
@@ -167,21 +142,14 @@ class TestCliPersistentE2E:
         assert "doc1.txt" in search_result.stdout
         assert "doc2.txt" in search_result.stdout
 
-    def test_search_persistent_no_matches(
-        self, temp_simgrep_home: pathlib.Path, sample_docs_dir_session: pathlib.Path
-    ) -> None:
+    def test_search_persistent_no_matches(self, temp_simgrep_home: pathlib.Path, sample_docs_dir_session: pathlib.Path) -> None:
         env_vars = {"HOME": str(temp_simgrep_home)}
         run_simgrep_command(["index", str(sample_docs_dir_session)], env=env_vars)
 
-        search_result = run_simgrep_command(
-            ["search", "nonexistentqueryxyz"], env=env_vars
-        )
+        search_result = run_simgrep_command(["search", "nonexistentqueryxyz"], env=env_vars)
         assert search_result.returncode == 0  # Should exit cleanly
         # Accept either 'No relevant chunks found' or only low scores in output
-        assert (
-            "No relevant chunks found" in search_result.stdout
-            or "Score:" in search_result.stdout
-        )
+        assert "No relevant chunks found" in search_result.stdout or "Score:" in search_result.stdout
 
     def test_status_after_index(
         self,
@@ -191,13 +159,7 @@ class TestCliPersistentE2E:
         env_vars = {"HOME": str(temp_simgrep_home)}
         run_simgrep_command(["index", str(sample_docs_dir_session)], env=env_vars)
 
-        db_file = (
-            temp_simgrep_home
-            / ".config"
-            / "simgrep"
-            / "default_project"
-            / "metadata.duckdb"
-        )
+        db_file = temp_simgrep_home / ".config" / "simgrep" / "default_project" / "metadata.duckdb"
         conn = duckdb.connect(str(db_file))
         files_count = conn.execute("SELECT COUNT(*) FROM indexed_files;").fetchone()[0]
         chunks_count = conn.execute("SELECT COUNT(*) FROM text_chunks;").fetchone()[0]
@@ -214,15 +176,11 @@ class TestCliPersistentE2E:
         assert status_result.returncode == 1
         assert "Default persistent index not found" in status_result.stdout
 
-        search_paths_result = run_simgrep_command(
-            ["search", "nonexistentqueryxyz", "--output", "paths"], env=env_vars
-        )
+        search_paths_result = run_simgrep_command(["search", "nonexistentqueryxyz", "--output", "paths"], env=env_vars)
         assert search_paths_result.returncode == 0
         assert "No matching files found." in search_paths_result.stdout
 
-    def test_search_persistent_index_not_exists(
-        self, temp_simgrep_home: pathlib.Path
-    ) -> None:
+    def test_search_persistent_index_not_exists(self, temp_simgrep_home: pathlib.Path) -> None:
         env_vars = {"HOME": str(temp_simgrep_home)}
         # Do not run index command
         search_result = run_simgrep_command(["search", "anything"], env=env_vars)
@@ -230,9 +188,7 @@ class TestCliPersistentE2E:
         assert "Default persistent index not found" in search_result.stdout
         assert "Please run 'simgrep index <path>' first" in search_result.stdout
 
-    def test_index_empty_directory(
-        self, temp_simgrep_home: pathlib.Path, tmp_path: pathlib.Path
-    ) -> None:
+    def test_index_empty_directory(self, temp_simgrep_home: pathlib.Path, tmp_path: pathlib.Path) -> None:
         env_vars = {"HOME": str(temp_simgrep_home)}
         empty_dir = tmp_path / "empty_docs_for_e2e"
         empty_dir.mkdir()
@@ -240,9 +196,7 @@ class TestCliPersistentE2E:
         index_result = run_simgrep_command(["index", str(empty_dir)], env=env_vars)
         assert index_result.returncode == 0
         assert "No files found to index" in index_result.stdout
-        assert (
-            "0 files processed" in index_result.stdout
-        )  # Or similar message indicating no work done
+        assert "0 files processed" in index_result.stdout  # Or similar message indicating no work done
 
         # Search should find nothing or report missing index
         search_result = run_simgrep_command(["search", "anything"], env=env_vars)
@@ -258,21 +212,27 @@ class TestCliPersistentE2E:
     ) -> None:
         env_vars = {"HOME": str(temp_simgrep_home)}
 
-        index_result = run_simgrep_command(
-            ["index", str(sample_docs_dir_session)], env=env_vars
-        )
+        index_result = run_simgrep_command(["index", str(sample_docs_dir_session)], env=env_vars)
         assert index_result.returncode == 0
         # doc3.md should be ignored by default patterns
-        assert (
-            "3 files processed" in index_result.stdout
-        )  # doc1.txt, doc2.txt, subdir/doc_sub.txt
+        assert "3 files processed" in index_result.stdout  # doc1.txt, doc2.txt, subdir/doc_sub.txt
 
-        search_result = run_simgrep_command(
-            ["search", "markdown"], env=env_vars
-        )  # "markdown" is in doc3.md
+        search_result = run_simgrep_command(["search", "markdown"], env=env_vars)  # "markdown" is in doc3.md
         assert search_result.returncode == 0
         # Accept either 'No relevant chunks found' or only low scores in output
-        assert (
-            "No relevant chunks found" in search_result.stdout
-            or "Score:" in search_result.stdout
-        )
+        assert "No relevant chunks found" in search_result.stdout or "Score:" in search_result.stdout
+
+    def test_search_top_option_limits_results(
+        self, temp_simgrep_home: pathlib.Path, sample_docs_dir_session: pathlib.Path
+    ) -> None:
+        env_vars = {"HOME": str(temp_simgrep_home)}
+
+        run_simgrep_command(["index", str(sample_docs_dir_session)], env=env_vars)
+
+        top1_result = run_simgrep_command(["search", "apples", "--top", "1"], env=env_vars)
+        assert top1_result.returncode == 0
+        assert top1_result.stdout.count("File:") == 1
+
+        top2_result = run_simgrep_command(["search", "apples", "--top", "2"], env=env_vars)
+        assert top2_result.returncode == 0
+        assert top2_result.stdout.count("File:") >= 2

--- a/tests/integration/test_indexer_parallel.py
+++ b/tests/integration/test_indexer_parallel.py
@@ -1,0 +1,72 @@
+import pathlib
+import pytest
+from rich.console import Console
+
+pytest.importorskip("duckdb")
+pytest.importorskip("transformers")
+pytest.importorskip("sentence_transformers")
+pytest.importorskip("usearch.index")
+
+from .test_indexer_persistent import sample_files_dir, test_console
+
+from simgrep.indexer import Indexer, IndexerConfig
+from simgrep.metadata_db import connect_persistent_db
+from simgrep.vector_store import load_persistent_index
+
+
+def _make_config(base_dir: pathlib.Path, project: str) -> IndexerConfig:
+    return IndexerConfig(
+        project_name=project,
+        db_path=base_dir / "metadata.duckdb",
+        usearch_index_path=base_dir / "index.usearch",
+        embedding_model_name="sentence-transformers/all-MiniLM-L6-v2",
+        chunk_size_tokens=128,
+        chunk_overlap_tokens=20,
+        file_scan_patterns=["*.txt", "*.md"],
+    )
+
+
+class TestIndexerParallel:
+    def test_parallel_matches_sequential(
+        self,
+        sample_files_dir: pathlib.Path,
+        test_console: Console,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        seq_dir = tmp_path / "seq"
+        conc_dir = tmp_path / "conc"
+        seq_dir.mkdir()
+        conc_dir.mkdir()
+
+        seq_cfg = _make_config(seq_dir, "seq_project")
+        conc_cfg = _make_config(conc_dir, "conc_project")
+
+        seq_indexer = Indexer(config=seq_cfg, console=test_console)
+        seq_indexer.index_path(target_path=sample_files_dir, wipe_existing=True, max_workers=1)
+
+        conc_indexer = Indexer(config=conc_cfg, console=test_console)
+        conc_indexer.index_path(target_path=sample_files_dir, wipe_existing=True, max_workers=4)
+
+        conn_seq = connect_persistent_db(seq_cfg.db_path)
+        conn_conc = connect_persistent_db(conc_cfg.db_path)
+        try:
+            files_seq = set(row[0] for row in conn_seq.execute("SELECT file_path FROM indexed_files;").fetchall())
+            files_conc = set(row[0] for row in conn_conc.execute("SELECT file_path FROM indexed_files;").fetchall())
+            assert files_seq == files_conc
+
+            query = (
+                "SELECT f.file_path, tc.chunk_text_snippet, tc.start_char_offset, tc.end_char_offset, tc.token_count "
+                "FROM text_chunks tc JOIN indexed_files f ON tc.file_id = f.file_id"
+            )
+            chunks_seq = set(conn_seq.execute(query).fetchall())
+            chunks_conc = set(conn_conc.execute(query).fetchall())
+            assert chunks_seq == chunks_conc
+        finally:
+            conn_seq.close()
+            conn_conc.close()
+
+        idx_seq = load_persistent_index(seq_cfg.usearch_index_path)
+        idx_conc = load_persistent_index(conc_cfg.usearch_index_path)
+        assert idx_seq is not None and idx_conc is not None
+        assert len(idx_seq) == len(idx_conc)
+        assert idx_seq.ndim == idx_conc.ndim

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from rich.console import Console
+
 import pytest
 
 from simgrep.formatter import format_paths
@@ -50,9 +52,10 @@ class TestFormatPaths:
         file1.write_text("1")
         file2.write_text("2")
 
-        result = format_paths([file1, file2], use_relative=True, base_path=None)
+        test_console = Console()
+        result = format_paths([file1, file2], use_relative=True, base_path=None, console=test_console)
         captured = capsys.readouterr()
-        assert "base_path was not provided to format_paths" in captured.err
+        assert "base_path was not provided to format_paths" in captured.out
 
         expected = "\n".join(
             sorted(

--- a/tests/unit/test_main_patterns.py
+++ b/tests/unit/test_main_patterns.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from simgrep.utils import gather_files_to_process
+
+
+class TestGatherFilesToProcess:
+    def test_single_pattern(self, tmp_path: Path) -> None:
+        (tmp_path / "a.txt").write_text("A")
+        (tmp_path / "b.md").write_text("B")
+        result = gather_files_to_process(tmp_path, ["*.txt"])
+        assert result == [(tmp_path / "a.txt").resolve()]
+
+    def test_multiple_patterns(self, tmp_path: Path) -> None:
+        file_txt = tmp_path / "a.txt"
+        file_md = tmp_path / "b.md"
+        file_csv = tmp_path / "c.csv"
+        file_txt.write_text("A")
+        file_md.write_text("B")
+        file_csv.write_text("C")
+        result = gather_files_to_process(tmp_path, ["*.txt", "*.md"])
+        assert set(result) == {file_txt.resolve(), file_md.resolve()}

--- a/tests/unit/test_search_inmemory_top.py
+++ b/tests/unit/test_search_inmemory_top.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pytest
+import usearch.index
+
+from simgrep.vector_store import search_inmemory_index
+
+pytest.importorskip("usearch.index")
+
+
+@pytest.fixture
+def simple_usearch_index() -> usearch.index.Index:
+    index = usearch.index.Index(ndim=3, metric="cos", dtype="f32")
+    keys = np.array([1, 2, 3], dtype=np.int64)
+    vectors = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], dtype=np.float32)
+    index.add(keys=keys, vectors=vectors)
+    return index
+
+
+def test_search_inmemory_respects_k(simple_usearch_index: usearch.index.Index) -> None:
+    query = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+    result_one = search_inmemory_index(simple_usearch_index, query, k=1)
+    assert len(result_one) == 1
+
+    result_two = search_inmemory_index(simple_usearch_index, query, k=2)
+    assert len(result_two) == 2

--- a/tests/unit/test_vector_store.py
+++ b/tests/unit/test_vector_store.py
@@ -1,0 +1,68 @@
+import numpy as np
+import pytest
+import usearch.index
+
+pytest.importorskip("numpy")
+pytest.importorskip("usearch.index")
+
+from simgrep.vector_store import create_inmemory_index, search_inmemory_index
+
+
+@pytest.fixture
+def simple_embeddings() -> np.ndarray:
+    return np.array(
+        [
+            [0.1, 0.2, 0.3],
+            [0.0, 0.1, 0.0],
+            [0.2, 0.2, 0.2],
+        ],
+        dtype=np.float32,
+    )
+
+
+@pytest.fixture
+def simple_labels() -> np.ndarray:
+    return np.array([10, 20, 30], dtype=np.int64)
+
+
+class TestCreateInmemoryIndex:
+    def test_valid_embeddings_and_labels(self, simple_embeddings: np.ndarray, simple_labels: np.ndarray) -> None:
+        index = create_inmemory_index(simple_embeddings, simple_labels)
+
+        assert isinstance(index, usearch.index.Index)
+        assert len(index) == simple_embeddings.shape[0]
+        assert index.ndim == simple_embeddings.shape[1]
+
+    def test_mismatched_shapes_raises(self) -> None:
+        embeddings = np.random.rand(3, 4).astype(np.float32)
+        labels = np.array([1, 2], dtype=np.int64)
+        with pytest.raises(ValueError, match="Number of embeddings \(3\) must match number of labels \(2\)"):
+            create_inmemory_index(embeddings, labels)
+
+    def test_empty_embeddings_raise(self) -> None:
+        embeddings = np.empty((0, 5), dtype=np.float32)
+        labels = np.empty((0,), dtype=np.int64)
+        with pytest.raises(ValueError, match="Embeddings array cannot be empty"):
+            create_inmemory_index(embeddings, labels)
+
+
+class TestSearchInmemoryIndex:
+    def test_search_returns_results(self, simple_embeddings: np.ndarray, simple_labels: np.ndarray) -> None:
+        index = create_inmemory_index(simple_embeddings, simple_labels)
+        query = simple_embeddings[0]
+        results = search_inmemory_index(index, query, k=2)
+
+        assert results
+        assert results[0][0] == simple_labels[0]
+        assert pytest.approx(1.0, abs=1e-5) == results[0][1]
+        assert len(results) <= 2
+
+    def test_dimension_mismatch_errors(self, simple_embeddings: np.ndarray, simple_labels: np.ndarray) -> None:
+        index = create_inmemory_index(simple_embeddings, simple_labels)
+        wrong_dim_query = np.random.rand(simple_embeddings.shape[1] + 1).astype(np.float32)
+        with pytest.raises(ValueError, match="does not match index dimension"):
+            search_inmemory_index(index, wrong_dim_query, k=1)
+
+        batch_query = np.random.rand(2, simple_embeddings.shape[1]).astype(np.float32)
+        with pytest.raises(ValueError, match="Expected a single query embedding"):
+            search_inmemory_index(index, batch_query, k=1)


### PR DESCRIPTION
## Summary
- support concurrent indexing with ThreadPoolExecutor in `index_path`
- lock database and vector index access for thread safety
- add test to compare concurrent and sequential runs

## Testing
- `pytest tests/integration/test_indexer_parallel.py -vv` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6841ed3fbabc8333a818215d4ad90832