### PR TITLE
Add bulk chunk retrieval APIs and update search

### DIFF
--- a/tests/unit/test_metadata_db.py
+++ b/tests/unit/test_metadata_db.py
@@ -10,6 +10,7 @@ from simgrep.metadata_db import (
     batch_insert_files,
     create_inmemory_db_connection,
     retrieve_chunk_for_display,
+    retrieve_chunks_for_display_bulk,
     setup_ephemeral_tables,
 )
 from simgrep.models import ChunkData
@@ -117,23 +118,17 @@ class TestMetadataDB:
 
         file_id_to_check = sample_files_metadata[0][0]
         expected_path = str(sample_files_metadata[0][1].resolve())
-        result = db_conn.execute(
-            "SELECT file_path FROM temp_files WHERE file_id = ?;", [file_id_to_check]
-        ).fetchone()
+        result = db_conn.execute("SELECT file_path FROM temp_files WHERE file_id = ?;", [file_id_to_check]).fetchone()
         assert result is not None
         assert result[0] == expected_path
 
-    def test_batch_insert_files_empty_list(
-        self, db_conn: duckdb.DuckDBPyConnection
-    ) -> None:
+    def test_batch_insert_files_empty_list(self, db_conn: duckdb.DuckDBPyConnection) -> None:
         batch_insert_files(db_conn, [])
         count_result = db_conn.execute("SELECT COUNT(*) FROM temp_files;").fetchone()
         assert count_result is not None
         assert count_result[0] == 0
 
-    def test_batch_insert_files_unique_constraint_path(
-        self, db_conn: duckdb.DuckDBPyConnection, tmp_path: pathlib.Path
-    ) -> None:
+    def test_batch_insert_files_unique_constraint_path(self, db_conn: duckdb.DuckDBPyConnection, tmp_path: pathlib.Path) -> None:
         file_path = tmp_path / "unique_test.txt"
         file_path.touch()
         metadata1 = [(0, file_path)]
@@ -141,14 +136,12 @@ class TestMetadataDB:
 
         # attempt to insert the same file path with a different id (should also fail due to unique path)
         # or, more directly for testing unique on file_path:
-        metadata2 = [(1, file_path)] # different id, same path
+        metadata2 = [(1, file_path)]  # different id, same path
         # temp_files.file_path has a unique constraint
         with pytest.raises(MetadataDBError, match="Failed during batch file insert"):
             batch_insert_files(db_conn, metadata2)
 
-    def test_batch_insert_files_duplicate_file_id(
-        self, db_conn: duckdb.DuckDBPyConnection, tmp_path: pathlib.Path
-    ) -> None:
+    def test_batch_insert_files_duplicate_file_id(self, db_conn: duckdb.DuckDBPyConnection, tmp_path: pathlib.Path) -> None:
         file_path1 = tmp_path / "file_A.txt"
         file_path1.touch()
         file_path2 = tmp_path / "file_B.txt"
@@ -186,9 +179,7 @@ class TestMetadataDB:
         assert result[1] == chunk_to_check.source_file_id
         assert result[2] == chunk_to_check.start_char_offset
 
-    def test_batch_insert_chunks_empty_list(
-        self, db_conn: duckdb.DuckDBPyConnection
-    ) -> None:
+    def test_batch_insert_chunks_empty_list(self, db_conn: duckdb.DuckDBPyConnection) -> None:
         batch_insert_chunks(db_conn, [])
         count_result = db_conn.execute("SELECT COUNT(*) FROM temp_chunks;").fetchone()
         assert count_result is not None
@@ -246,9 +237,7 @@ class TestMetadataDB:
         assert start_offset == chunk_to_retrieve.start_char_offset
         assert end_offset == chunk_to_retrieve.end_char_offset
 
-    def test_retrieve_chunk_for_display_invalid_id(
-        self, db_conn: duckdb.DuckDBPyConnection
-    ) -> None:
+    def test_retrieve_chunk_for_display_invalid_id(self, db_conn: duckdb.DuckDBPyConnection) -> None:
         retrieved = retrieve_chunk_for_display(db_conn, 99999)  # non-existent id
         assert retrieved is None
 
@@ -289,6 +278,42 @@ class TestMetadataDB:
         retrieved = retrieve_chunk_for_display(db_conn, chunk_to_retrieve_label)
 
         # the join should fail to find a match in temp_files (and temp_chunks), so result should be none
-        assert (
-            retrieved is None
-        ), "Should not retrieve chunk if its corresponding file_id is missing from temp_files or chunk itself is deleted"
+        assert retrieved is None, (
+            "Should not retrieve chunk if its corresponding file_id is missing from temp_files or chunk itself is deleted"
+        )
+
+    def test_retrieve_chunks_for_display_bulk(
+        self,
+        db_conn: duckdb.DuckDBPyConnection,
+        sample_files_metadata: list[tuple[int, pathlib.Path]],
+        sample_chunk_data_list: list[ChunkData],
+    ) -> None:
+        batch_insert_files(db_conn, sample_files_metadata)
+        batch_insert_chunks(db_conn, sample_chunk_data_list)
+
+        ids = [c.usearch_label for c in sample_chunk_data_list]
+        results = retrieve_chunks_for_display_bulk(db_conn, ids)
+
+        assert len(results) == len(ids)
+        for chunk in sample_chunk_data_list:
+            assert chunk.usearch_label in results
+            text, path, start, end = results[chunk.usearch_label]
+            assert text == chunk.text
+            assert path == chunk.source_file_path.resolve()
+            assert start == chunk.start_char_offset
+            assert end == chunk.end_char_offset
+
+    def test_retrieve_chunks_for_display_bulk_with_missing(
+        self,
+        db_conn: duckdb.DuckDBPyConnection,
+        sample_files_metadata: list[tuple[int, pathlib.Path]],
+        sample_chunk_data_list: list[ChunkData],
+    ) -> None:
+        batch_insert_files(db_conn, sample_files_metadata)
+        batch_insert_chunks(db_conn, sample_chunk_data_list)
+
+        ids = [sample_chunk_data_list[0].usearch_label, 99999]
+        results = retrieve_chunks_for_display_bulk(db_conn, ids)
+
+        assert sample_chunk_data_list[0].usearch_label in results
+        assert 99999 not in results


### PR DESCRIPTION
## Summary
- add duckdb bulk retrieval helpers
- retrieve search results using the new bulk functions
- test the new bulk retrieval for ephemeral and persistent DBs

## Testing
- `uv run pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_6841ed3a165c8333b816e000d106ef1d