### PR TITLE
Add batch size option for embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ When you run `simgrep "your query" ./path/to/search`:
 *   **Processing:**
     *   Extracts text from files using `unstructured`.
     *   Chunks text using token-based strategies (configurable model, size, overlap - defaults used for now).
-    *   Generates embeddings for your query and text chunks (uses `sentence-transformers`).
-    *   Manages chunk metadata (source file, offsets) using an in-memory DuckDB.
+*   Generates embeddings for your query and text chunks (uses `sentence-transformers`).
+*   Embedding generation batch size is configurable via `default_embedding_batch_size` (defaults to 32).
+*   Manages chunk metadata (source file, offsets) using an in-memory DuckDB.
 *   **Finds & Displays:**
     *   Performs semantic similarity search using an in-memory USearch index.
     *   Outputs results showing the relevant file, similarity score, and the text chunk (`--output show`, default).

--- a/simgrep/indexer.py
+++ b/simgrep/indexer.py
@@ -53,6 +53,7 @@ class IndexerConfig(BaseModel):
     embedding_model_name: str
     chunk_size_tokens: int
     chunk_overlap_tokens: int
+    embedding_batch_size: int = 32
     file_scan_patterns: List[str] = Field(default_factory=lambda: ["*.txt"])
 
 
@@ -80,7 +81,11 @@ class Indexer:
             self.console.print("Embedding model loaded.")
 
             self.console.print("Determining embedding dimension...")
-            dummy_emb = generate_embeddings(["simgrep_test_string"], model=self.embedding_model)
+            dummy_emb = generate_embeddings(
+                ["simgrep_test_string"],
+                model=self.embedding_model,
+                batch_size=self.config.embedding_batch_size,
+            )
             if dummy_emb.ndim != 2 or dummy_emb.shape[0] == 0 or dummy_emb.shape[1] == 0:
                 raise IndexerError(
                     f"Could not determine embedding dimension using model {self.config.embedding_model_name}. "
@@ -231,7 +236,11 @@ class Indexer:
 
             # embedding & storing chunks
             chunk_texts = [chunk["text"] for chunk in processed_chunks]
-            embeddings_np = generate_embeddings(chunk_texts, model=self.embedding_model)
+            embeddings_np = generate_embeddings(
+                chunk_texts,
+                model=self.embedding_model,
+                batch_size=self.config.embedding_batch_size,
+            )
 
             chunk_db_records: List[Dict[str, Any]] = []
             usearch_labels_for_batch: List[int] = []

--- a/simgrep/main.py
+++ b/simgrep/main.py
@@ -392,6 +392,7 @@ def search(
             query_embedding = generate_embeddings(
                 texts=[query_text],
                 model=embedding_model_instance,  # Pass pre-loaded model
+                batch_size=global_simgrep_config.default_embedding_batch_size,
             )
             console.print(f"    Query embedding shape: {query_embedding.shape}")
 
@@ -400,6 +401,7 @@ def search(
             chunk_embeddings = generate_embeddings(
                 texts=chunk_texts_for_embedding,
                 model=embedding_model_instance,  # Pass pre-loaded model
+                batch_size=global_simgrep_config.default_embedding_batch_size,
             )
             console.print(f"    Chunk embeddings shape: {chunk_embeddings.shape}")
 
@@ -556,6 +558,7 @@ def index(
             db_path=default_project_db_file,
             usearch_index_path=default_project_usearch_file,
             embedding_model_name=global_simgrep_config.default_embedding_model_name,
+            embedding_batch_size=global_simgrep_config.default_embedding_batch_size,
             chunk_size_tokens=global_simgrep_config.default_chunk_size_tokens,
             chunk_overlap_tokens=global_simgrep_config.default_chunk_overlap_tokens,
             file_scan_patterns=["*.txt"],  # Initially hardcode to .txt, make configurable later

--- a/simgrep/models.py
+++ b/simgrep/models.py
@@ -48,6 +48,7 @@ class SimgrepConfig(BaseModel):
     default_embedding_model_name: str = "sentence-transformers/all-MiniLM-L6-v2"
     default_chunk_size_tokens: int = 128
     default_chunk_overlap_tokens: int = 20
+    default_embedding_batch_size: int = 32
 
     # llm_api_key: Optional[str] = None # deferred to a later phase (e.g., rag implementation)
     # projects: List[ProjectConfig] = Field(default_factory=list) # deferred to deliverable 4.4

--- a/simgrep/processor.py
+++ b/simgrep/processor.py
@@ -122,6 +122,8 @@ def generate_embeddings(
     texts: List[str],
     model_name: str = "sentence-transformers/all-MiniLM-L6-v2",
     model: Optional[SentenceTransformer] = None,
+    *,
+    batch_size: Optional[int] = None,
 ) -> np.ndarray:
     """
     Generates vector embeddings for a list of input texts using a specified
@@ -145,7 +147,11 @@ def generate_embeddings(
         else:
             active_model = model
 
-        embeddings = active_model.encode(texts, show_progress_bar=False)
+        encode_kwargs = {"show_progress_bar": False}
+        if batch_size is not None:
+            encode_kwargs["batch_size"] = batch_size
+
+        embeddings = active_model.encode(texts, **encode_kwargs)
         return embeddings
     except Exception as e:
         # Determine which model name to report in the error

--- a/simgrep/searcher.py
+++ b/simgrep/searcher.py
@@ -37,7 +37,9 @@ def perform_persistent_search(
     )
     try:
         query_embedding = generate_embeddings(
-            texts=[query_text], model_name=embedding_model_name
+            texts=[query_text],
+            model_name=embedding_model_name,
+            batch_size=global_config.default_embedding_batch_size,
         )
     except RuntimeError as e:
         console.print(

--- a/tests/integration/test_indexer_persistent.py
+++ b/tests/integration/test_indexer_persistent.py
@@ -29,6 +29,7 @@ def indexer_config(temp_project_dir: pathlib.Path) -> IndexerConfig:
         db_path=temp_project_dir / "metadata.duckdb",
         usearch_index_path=temp_project_dir / "index.usearch",
         embedding_model_name="sentence-transformers/all-MiniLM-L6-v2",
+        embedding_batch_size=32,
         chunk_size_tokens=128,  # Default from SimgrepConfig
         chunk_overlap_tokens=20,  # Default from SimgrepConfig
         file_scan_patterns=["*.txt", "*.md"],

--- a/tests/integration/test_searcher_persistent_integration.py
+++ b/tests/integration/test_searcher_persistent_integration.py
@@ -87,6 +87,7 @@ def populated_persistent_index_for_searcher(
         db_path=db_file,
         usearch_index_path=usearch_file,
         embedding_model_name=cfg.default_embedding_model_name,
+        embedding_batch_size=cfg.default_embedding_batch_size,
         chunk_size_tokens=cfg.default_chunk_size_tokens,
         chunk_overlap_tokens=cfg.default_chunk_overlap_tokens,
         file_scan_patterns=["*.txt"],

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -33,6 +33,7 @@ class TestSimgrepConfig:
             assert config.default_embedding_model_name == "sentence-transformers/all-MiniLM-L6-v2"
             assert config.default_chunk_size_tokens == 128
             assert config.default_chunk_overlap_tokens == 20
+            assert config.default_embedding_batch_size == 32
 
             # Check that the directory was created
             assert expected_data_dir.exists()
@@ -114,5 +115,6 @@ class TestSimgrepConfig:
         assert config.default_embedding_model_name == "sentence-transformers/all-MiniLM-L6-v2"
         assert config.default_chunk_size_tokens == 128
         assert config.default_chunk_overlap_tokens == 20
+        assert config.default_embedding_batch_size == 32
         # assert config.llm_api_key is None # If/when added
         # assert config.projects == []      # If/when added

--- a/tests/unit/test_processor.py
+++ b/tests/unit/test_processor.py
@@ -364,6 +364,21 @@ class TestGenerateEmbeddings:
         ):
             generate_embeddings(texts, model_name=self.INVALID_MODEL_NAME)
 
+    def test_embeddings_consistent_across_batch_sizes(
+        self, sentence_transformer_model: "SentenceTransformer"
+    ) -> None:  # type: ignore # noqa: F821
+        import numpy as np
+
+        from simgrep.processor import generate_embeddings
+
+        texts = ["one", "two", "three"]
+        emb_default = generate_embeddings(texts, model=sentence_transformer_model)
+        emb_bs1 = generate_embeddings(texts, model=sentence_transformer_model, batch_size=1)
+        emb_bs2 = generate_embeddings(texts, model=sentence_transformer_model, batch_size=2)
+
+        assert np.allclose(emb_default, emb_bs1, rtol=1e-5, atol=1e-6)
+        assert np.allclose(emb_default, emb_bs2, rtol=1e-5, atol=1e-6)
+
 
 class TestCalculateFileHash:
     def test_calculate_file_hash_valid_file(self, temp_text_file: Path) -> None:


### PR DESCRIPTION
## Summary
- allow `generate_embeddings` to take `batch_size`
- pass batch size from config in indexer, searcher, and main
- document new config option in README
- ensure default batch size in `SimgrepConfig`
- test embedding equality across different batch sizes

## Testing
- `pytest -q tests/unit/test_processor.py::TestGenerateEmbeddings::test_embeddings_consistent_across_batch_sizes -q`
- `pytest -q` *(fails: KeyboardInterrupt after 7 tests; heavy environment)*

------
https://chatgpt.com/codex/tasks/task_e_6841ed436b8c833385abeaa8896c4011