### PR TITLE
Add ephemeral search E2E test

### DIFF
--- a/tests/e2e/test_cli_ephemeral_e2e.py
+++ b/tests/e2e/test_cli_ephemeral_e2e.py
@@ -1,0 +1,39 @@
+import pathlib
+
+import pytest
+
+from .test_cli_persistent_e2e import (
+    run_simgrep_command,
+)
+from .test_cli_persistent_e2e import (
+    temp_simgrep_home as _temp_simgrep_home,
+)
+
+temp_simgrep_home = _temp_simgrep_home  # re-export for pytest
+
+pytest.importorskip("sentence_transformers")
+pytest.importorskip("usearch.index")
+
+
+class TestCliEphemeralE2E:
+    def test_ephemeral_search_show_and_paths(self, tmp_path: pathlib.Path, temp_simgrep_home: pathlib.Path) -> None:
+        docs_dir = tmp_path / "ephemeral_docs"
+        docs_dir.mkdir()
+        file1 = docs_dir / "one.txt"
+        file1.write_text("apples bananas")
+        file2 = docs_dir / "two.txt"
+        file2.write_text("bananas oranges")
+
+        env_vars = {"HOME": str(temp_simgrep_home)}
+
+        show_result = run_simgrep_command(
+            ["search", "bananas", str(docs_dir)], env=env_vars
+        )
+        assert show_result.returncode == 0
+        assert "File:" in show_result.stdout
+
+        paths_result = run_simgrep_command(
+            ["search", "bananas", str(docs_dir), "--output", "paths"], env=env_vars
+        )
+        assert paths_result.returncode == 0
+        assert ".txt" in paths_result.stdout

--- a/tests/e2e/test_cli_persistent_e2e.py
+++ b/tests/e2e/test_cli_persistent_e2e.py
@@ -199,8 +199,12 @@ class TestCliPersistentE2E:
             / "metadata.duckdb"
         )
         conn = duckdb.connect(str(db_file))
-        files_count = conn.execute("SELECT COUNT(*) FROM indexed_files;").fetchone()[0]
-        chunks_count = conn.execute("SELECT COUNT(*) FROM text_chunks;").fetchone()[0]
+        files_count = conn.execute(
+            "SELECT COUNT(*) FROM indexed_files;"
+        ).fetchone()[0]  # type: ignore[index]
+        chunks_count = conn.execute(
+            "SELECT COUNT(*) FROM text_chunks;"
+        ).fetchone()[0]  # type: ignore[index]
         conn.close()
 
         status_result = run_simgrep_command(["status"], env=env_vars)


### PR DESCRIPTION
## Summary
- cover ephemeral search path in CLI
- ignore mypy error in persistent test for duckdb fetchone

## Testing
- `mypy tests/e2e/test_cli_ephemeral_e2e.py`
- `pytest -q tests/e2e/test_cli_ephemeral_e2e.py`

------
https://chatgpt.com/codex/tasks/task_e_6841ed5634088333b138541bc482f570