### PR TITLE
Improve persistent search model loading

### DIFF
--- a/simgrep/searcher.py
+++ b/simgrep/searcher.py
@@ -1,9 +1,10 @@
 import pathlib
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import duckdb
 import usearch.index
 from rich.console import Console
+from sentence_transformers import SentenceTransformer
 
 from .config import DEFAULT_K_RESULTS, SimgrepConfig
 from .exceptions import MetadataDBError, VectorStoreError
@@ -14,6 +15,15 @@ from .processor import generate_embeddings
 from .vector_store import (
     search_inmemory_index,  # this function is generic for any usearch index
 )
+
+_embedding_model_cache: Dict[str, SentenceTransformer] = {}
+
+
+def _load_embedding_model(model_name: str) -> SentenceTransformer:
+    """Load and cache a SentenceTransformer model by name."""
+    if model_name not in _embedding_model_cache:
+        _embedding_model_cache[model_name] = SentenceTransformer(model_name)
+    return _embedding_model_cache[model_name]
 
 
 def perform_persistent_search(
@@ -32,17 +42,15 @@ def perform_persistent_search(
     Orchestrates the search process against a pre-existing, loaded persistent index.
     """
     embedding_model_name = global_config.default_embedding_model_name
-    console.print(
-        f"  Embedding query: '[italic blue]{query_text}[/italic blue]' using model '{embedding_model_name}'..."
-    )
+    console.print(f"  Embedding query: '[italic blue]{query_text}[/italic blue]' using model '{embedding_model_name}'...")
     try:
+        embedding_model = _load_embedding_model(embedding_model_name)
         query_embedding = generate_embeddings(
-            texts=[query_text], model_name=embedding_model_name
+            texts=[query_text],
+            model=embedding_model,
         )
     except RuntimeError as e:
-        console.print(
-            f"[bold red]Failed to generate query embedding:[/bold red]\n  {e}"
-        )
+        console.print(f"[bold red]Failed to generate query embedding:[/bold red]\n  {e}")
         raise  # re-raise for main.py to catch and exit
 
     console.print(f"  Searching persistent index for top {k_results} similar chunks...")
@@ -55,9 +63,7 @@ def perform_persistent_search(
         raise  # re-raise
 
     # Filter by min_score
-    filtered_matches = [
-        (label, score) for (label, score) in search_matches if score >= min_score
-    ]
+    filtered_matches = [(label, score) for (label, score) in search_matches if score >= min_score]
 
     if not filtered_matches:
         if output_mode == OutputMode.paths:
@@ -75,14 +81,10 @@ def perform_persistent_search(
 
     # process and format results
     if output_mode == OutputMode.show:
-        console.print(
-            f"\n[bold cyan]Search Results (Top {len(filtered_matches)} from persistent index):[/bold cyan]"
-        )
+        console.print(f"\n[bold cyan]Search Results (Top {len(filtered_matches)} from persistent index):[/bold cyan]")
         for matched_usearch_label, similarity_score in filtered_matches:
             try:
-                retrieved_details = retrieve_chunk_details_persistent(
-                    db_conn, matched_usearch_label
-                )
+                retrieved_details = retrieve_chunk_details_persistent(db_conn, matched_usearch_label)
             except MetadataDBError as e:
                 console.print(
                     f"[yellow]Warning: Database error retrieving details for chunk label {matched_usearch_label}: {e}[/yellow]"
@@ -107,9 +109,7 @@ def perform_persistent_search(
         unique_paths_seen = set()  # to ensure uniqueness before format_paths
         for matched_usearch_label, _similarity_score in filtered_matches:
             try:
-                retrieved_details = retrieve_chunk_details_persistent(
-                    db_conn, matched_usearch_label
-                )
+                retrieved_details = retrieve_chunk_details_persistent(db_conn, matched_usearch_label)
             except MetadataDBError as e:
                 console.print(
                     f"[yellow]Warning: Database error retrieving path for chunk label {matched_usearch_label}: {e}[/yellow]"
@@ -122,9 +122,7 @@ def perform_persistent_search(
                     paths_from_matches.append(file_path_obj)
                     unique_paths_seen.add(file_path_obj)
             else:
-                console.print(
-                    f"[yellow]Warning: Could not retrieve path for chunk label {matched_usearch_label}.[/yellow]"
-                )
+                console.print(f"[yellow]Warning: Could not retrieve path for chunk label {matched_usearch_label}.[/yellow]")
 
         output_string = format_paths(
             file_paths=paths_from_matches,  # already unique

--- a/tests/unit/test_searcher_persistent.py
+++ b/tests/unit/test_searcher_persistent.py
@@ -1,0 +1,54 @@
+import duckdb
+import numpy as np
+import pytest
+from rich.console import Console
+
+pytest.importorskip("sentence_transformers")
+
+import simgrep.searcher as searcher
+from simgrep.models import OutputMode, SimgrepConfig
+
+
+class TestPersistentSearcherCaching:
+    def test_model_loaded_once_for_repeated_searches(self, tmp_path, monkeypatch):
+        call_counter = {"count": 0}
+
+        class DummyModel:
+            def __init__(self, name: str) -> None:
+                call_counter["count"] += 1
+                self.name = name
+
+            def encode(self, texts, show_progress_bar=False):  # noqa: D401
+                return np.zeros((len(texts), 3), dtype=np.float32)
+
+        monkeypatch.setattr(searcher, "SentenceTransformer", DummyModel)
+
+        def fake_search_inmemory_index(index, query_embedding, k):  # noqa: D401
+            return []
+
+        monkeypatch.setattr(searcher, "search_inmemory_index", fake_search_inmemory_index)
+
+        cfg = SimgrepConfig(default_project_data_dir=tmp_path)
+        console = Console(quiet=True)
+        db_conn = duckdb.connect(":memory:")
+
+        searcher._embedding_model_cache.clear()
+        searcher.perform_persistent_search(
+            query_text="first",
+            console=console,
+            db_conn=db_conn,
+            vector_index=None,  # type: ignore[arg-type]
+            global_config=cfg,
+            output_mode=OutputMode.show,
+        )
+        assert call_counter["count"] == 1
+
+        searcher.perform_persistent_search(
+            query_text="second",
+            console=console,
+            db_conn=db_conn,
+            vector_index=None,  # type: ignore[arg-type]
+            global_config=cfg,
+            output_mode=OutputMode.show,
+        )
+        assert call_counter["count"] == 1


### PR DESCRIPTION
## Summary
- cache SentenceTransformer models in searcher
- embed persistent search queries using the cached model
- add tests covering model caching

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'langdetect')*

------
https://chatgpt.com/codex/tasks/task_e_6841ed53a5a88333b8e34e20ce1b8885