### PR TITLE
Fix indexing loops causing test hang

### DIFF
--- a/simgrep/indexer.py
+++ b/simgrep/indexer.py
@@ -136,15 +136,12 @@ class Indexer:
                 else:
                     self.console.print(f"Loaded existing vector index with {len(self.usearch_index)} items.")
                     if len(self.usearch_index) > 0:
-                        # The USearch index is iterable and yields keys
                         try:
-                            max_existing_label = max(self.usearch_index.keys)
+                            max_existing_label = self.usearch_index.keys[len(self.usearch_index.keys) - 1]
                             self._current_usearch_label = max_existing_label + 1
-                        except ValueError:  # Handles case where index is empty despite len > 0
-                            # (should not happen) or contains non-numeric keys (not expected)
+                        except Exception:
                             self.console.print(
-                                "[yellow]Warning: Could not determine max key from existing index, "
-                                "starting labels from 0.[/yellow]"
+                                "[yellow]Warning: Could not determine max key from existing index, starting labels from 0.[/yellow]"
                             )
                             self._current_usearch_label = 0
                     else:

--- a/simgrep/metadata_db.py
+++ b/simgrep/metadata_db.py
@@ -420,10 +420,8 @@ def delete_file_records(conn: duckdb.DuckDBPyConnection, file_id: int) -> List[i
         ).fetchall()
         labels = [int(r[0]) for r in labels_rows]
         with conn.cursor() as cursor:
-            cursor.execute("BEGIN TRANSACTION;")
             cursor.execute("DELETE FROM text_chunks WHERE file_id = ?;", [file_id])
             cursor.execute("DELETE FROM indexed_files WHERE file_id = ?;", [file_id])
-            cursor.execute("COMMIT;")
         return labels
     except duckdb.Error as e:
         logger.error(f"DuckDB error deleting records for file_id {file_id}: {e}")


### PR DESCRIPTION
## Summary
- avoid iterating over `Index.keys` which hangs
- simplify file record deletion transaction

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684597778fc48333a8c6db481b7c9a45