### PR TITLE
Document import tree feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ When you run `simgrep "your query" ./path/to/search`:
     *   Performs semantic similarity search using an in-memory USearch index.
     *   Outputs results showing the relevant file, similarity score, and the text chunk (`--output show`, default).
     *   Lists unique file paths containing matches (`--output paths`).
+    *   Display a full dependency tree for a code file (`--output imports`).
     *   Limit the number of matches returned with `--top N` (alias `--k`).
 
 ### Examples

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,6 +34,7 @@ The tool is designed to be intuitive for simple use cases ("semantic grep replac
 *   **Performance:** Fast indexing (especially incremental) and search.
 *   **Flexibility:** Support various file types and configurable embedding models.
 *   **Versatile Output Modes:** Cater to diverse workflows including RAG, code retrieval, and information discovery.
+*   **Import Graph Extraction:** Output complete dependency trees for supported programming languages (initially Python, TypeScript, Java).
 *   **Lean & Modern Stack:** Utilize `uv` for project management, `mypy` for strict typing, DuckDB for metadata, and USearch for vector indexing.
 
 **3. Non-Goals**
@@ -122,6 +123,12 @@ The tool is designed to be intuitive for simple use cases ("semantic grep replac
         *   File Parsing: Extracts text content from various file types.
         *   Text Chunking: Splits text into manageable, semantically coherent chunks using token-based strategies (configurable size and overlap).
         *   Embedding Generation: Converts text chunks into vector embeddings using the configured model.
+*   **Import Dependency Analyzer (`dependency_analyzer.py`):**
+    *   Technology: Python `ast`, TypeScript/Java parsers (`tree-sitter` or language-specific libraries).
+    *   Responsibilities:
+        *   Parse code files to detect `import` statements and resolve file/module paths.
+        *   Recursively walk dependencies to build a full import tree for supported languages (Python, TypeScript, Java).
+        *   Provide data structures for the Output Formatter to display or serialize the dependency graph.
 *   **Vector Store (USearch) (`vector_store.py`):**
     *   Technology: `usearch`.
     *   Responsibilities: Stores, manages, and searches dense vector embeddings. Persists index to disk. Provides unique labels for vectors.
@@ -192,6 +199,10 @@ The tool is designed to be intuitive for simple use cases ("semantic grep replac
         *   `end_char_offset INTEGER`
         *   `token_count INTEGER`
         *   `embedding_hash VARCHAR` (Hash of the embedding vector, for potential future use)
+    *   `file_dependencies`:
+        *   `file_id INTEGER REFERENCES indexed_files(file_id) ON DELETE CASCADE`
+        *   `imports_file_id INTEGER REFERENCES indexed_files(file_id) ON DELETE CASCADE`
+        *   `PRIMARY KEY (file_id, imports_file_id)`
 
 **5.4. Configuration Management**
 
@@ -280,6 +291,7 @@ The tool is designed to be intuitive for simple use cases ("semantic grep replac
     *   `copy-chunks`: Concatenates only the relevant chunk texts (with their source file path as a comment/header) and copies to clipboard.
     *   `json`: Outputs detailed results (file path, chunk text, score, offsets, metadata) as a JSON array.
     *   `count`: Shows number of matching chunks and files.
+    *   `imports`: Displays the full dependency tree for a single code file, recursively resolving imports for Python, TypeScript, and Java.
 
 **7. User Experience (UX) Design**
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -413,6 +413,36 @@
 
 ---
 
+**Phase 7: Import Dependency Extraction**
+
+*Goal: Provide a way to output the full import tree for a given source file.*
+
+* **Deliverable 7.1: `dependency_analyzer.py`**
+  * **Goal:** Parse direct imports for supported languages.
+  * **Tasks:**
+        1. Create new module `dependency_analyzer.py` with language-specific parsers (Python `ast`, TypeScript/Java via `tree-sitter` or similar).
+        2. Implement `get_direct_imports(file_path: Path) -> List[Path]` resolving files within indexed paths.
+  * **Key Modules:** `simgrep/dependency_analyzer.py`
+  * **What to Test:** Unit tests on sample Python/TS/Java files verifying import detection.
+
+* **Deliverable 7.2: Recursive Import Graph**
+  * **Goal:** Build a dependency tree by following imports recursively.
+  * **Tasks:**
+        1. Add function `build_import_tree(file_path: Path, seen: Set[Path]) -> Dict[Path, List[Path]]`.
+        2. Handle cycles gracefully and limit traversal to project files.
+  * **Key Modules:** `dependency_analyzer.py`
+  * **What to Test:** Import graph generation on small code samples with nested imports.
+
+* **Deliverable 7.3: `imports` Output Mode**
+  * **Goal:** Expose import tree via the CLI.
+  * **Tasks:**
+        1. Add `imports` to `--output` Enum in `main.py` and `formatter.py`.
+        2. Format results as a readable tree or JSON list of paths.
+  * **Key Modules:** `simgrep/main.py`, `simgrep/formatter.py`, `simgrep/dependency_analyzer.py`
+  * **What to Test (E2E):** `simgrep search main.py --output imports` shows the transitive list of imports.
+
+---
+
 **Cross-Cutting Concerns (Throughout Development):**
 
 * **Version Control:** `git init` from D0.1. Commit after each deliverable.


### PR DESCRIPTION
## Summary
- add import graph extraction bullet in architecture
- describe dependency analyzer component and file_dependencies table
- include new `imports` output mode
- outline Phase 7 for import dependency extraction in implementation plan
- mention imports output mode in README

## Testing
- `make format`
- `make lint`
- `make test` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68459832188c8333a379bd90eb2e3e9a