### PR TITLE
Add tests for custom search top value

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Search both text and markdown files:
 simgrep search "apples" docs --pattern "*.txt" --pattern "*.md"
 ```
 
+Limit results to the top 3 matches:
+
+```bash
+simgrep search "apples" docs --top 3
+```
+
 ## Near Future Plans (Persistent Indexing - Phase 3)
 
 *   **Persistent Indexing:**

--- a/tests/integration/test_searcher_persistent_integration.py
+++ b/tests/integration/test_searcher_persistent_integration.py
@@ -249,3 +249,42 @@ class TestSearcherPersistentIntegration:
         assert (
             "No matching files found." in captured.out
         ), "Expected 'no results' message for paths mode."
+
+    def test_perform_persistent_search_respects_k_results(
+        self,
+        populated_persistent_index_for_searcher: Tuple[
+            duckdb.DuckDBPyConnection,
+            usearch.index.Index,
+            SimgrepConfig,
+        ],
+        test_console: Console,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        db_conn, vector_index_val, global_cfg = populated_persistent_index_for_searcher
+        query = "simgrep"
+
+        perform_persistent_search(
+            query_text=query,
+            console=test_console,
+            db_conn=db_conn,
+            vector_index=vector_index_val,
+            global_config=global_cfg,
+            output_mode=OutputMode.show,
+            k_results=1,
+            min_score=0.1,
+        )
+        out_one = capsys.readouterr().out
+        assert out_one.count("---") == 1
+
+        perform_persistent_search(
+            query_text=query,
+            console=test_console,
+            db_conn=db_conn,
+            vector_index=vector_index_val,
+            global_config=global_cfg,
+            output_mode=OutputMode.show,
+            k_results=2,
+            min_score=0.1,
+        )
+        out_two = capsys.readouterr().out
+        assert out_two.count("---") >= 2


### PR DESCRIPTION
## Summary
- document the `--top` search option in README
- test `perform_persistent_search` respects different `k_results`

## Testing
- `pytest tests/integration/test_searcher_persistent_integration.py::TestSearcherPersistentIntegration::test_perform_persistent_search_respects_k_results -q`
- `pytest tests/unit/test_search_inmemory_top.py::test_search_inmemory_respects_k tests/integration/test_searcher_persistent_integration.py::TestSearcherPersistentIntegration::test_perform_persistent_search_respects_k_results -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b7ccaa788333922722c9caf45ea1