### PR TITLE
Add pattern option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ When you run `simgrep "your query" ./path/to/search`:
 
 *   **Searches:**
     *   A single file.
-    *   Recursively through a directory (files matching `--pattern`; defaults to `*.txt`).
+    *   Recursively through a directory. Use `--pattern` to specify glob(s) for files (defaults to `*.txt`). Pass multiple `--pattern` options to include several patterns.
 *   **Processing:**
     *   Extracts text from files using `unstructured`.
     *   Chunks text using token-based strategies (configurable model, size, overlap - defaults used for now).

--- a/simgrep/main.py
+++ b/simgrep/main.py
@@ -157,11 +157,12 @@ def search(
         resolve_path=True,
         help="The path to a text file or directory for ephemeral search. If omitted, searches the default persistent index.",
     ),
-    patterns: Optional[List[str]] = typer.Option(
+    patterns: Optional[Tuple[str, ...]] = typer.Option(
         None,
         "--pattern",
         "-p",
         help="Glob pattern(s) for files when searching directories. Can be used multiple times. Defaults to '*.txt'.",
+        multiple=True,
     ),
     output: OutputMode = typer.Option(
         OutputMode.show,  # Default output mode
@@ -289,7 +290,7 @@ def search(
         files_to_process: List[Path] = []
         files_skipped: List[Tuple[Path, str]] = []
 
-        search_patterns = patterns or ["*.txt"]
+        search_patterns = list(patterns) if patterns else ["*.txt"]
         files_to_process = gather_files_to_process(path_to_search, search_patterns)
 
         if path_to_search.is_file():


### PR DESCRIPTION
## Summary
- enable repeating `--pattern` option for search
- clarify pattern usage in README

## Testing
- `pytest tests/unit/test_main_patterns.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b7cf7f848333b6df7ca0658ee931