### PR TITLE
Add progress bar to ephemeral search

### DIFF
--- a/tests/e2e/test_cli_ephemeral_e2e.py
+++ b/tests/e2e/test_cli_ephemeral_e2e.py
@@ -26,14 +26,14 @@ class TestCliEphemeralE2E:
 
         env_vars = {"HOME": str(temp_simgrep_home)}
 
-        show_result = run_simgrep_command(
-            ["search", "bananas", str(docs_dir)], env=env_vars
-        )
+        show_result = run_simgrep_command(["search", "bananas", str(docs_dir)], env=env_vars)
         assert show_result.returncode == 0
         assert "File:" in show_result.stdout
+        assert "Processing:" in show_result.stdout
+        assert "100%" in show_result.stdout
 
-        paths_result = run_simgrep_command(
-            ["search", "bananas", str(docs_dir), "--output", "paths"], env=env_vars
-        )
+        paths_result = run_simgrep_command(["search", "bananas", str(docs_dir), "--output", "paths"], env=env_vars)
         assert paths_result.returncode == 0
         assert ".txt" in paths_result.stdout
+        assert "Processing:" in paths_result.stdout
+        assert "100%" in paths_result.stdout


### PR DESCRIPTION
## Summary
- display a Rich progress bar during ephemeral search
- include percentage and current file being processed
- update e2e tests to expect the progress output

## Testing
- `ruff check simgrep/main.py tests/e2e/test_cli_ephemeral_e2e.py --fix`
- `ruff format simgrep/main.py tests/e2e/test_cli_ephemeral_e2e.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845b7d23b5c8333b1b8acd272ac250c