### PR TITLE
Ensure warnings printed via Rich console

### DIFF
--- a/simgrep/formatter.py
+++ b/simgrep/formatter.py
@@ -30,11 +30,13 @@ def format_paths(
     """
     Formats a list of file paths for display. Paths are unique and sorted.
     Can display absolute paths or paths relative to a base_path.
+    Optionally accepts a Rich ``Console`` instance for emitting warnings.
 
     Args:
         file_paths: A list of Path objects.
         use_relative: If True, attempts to make paths relative to base_path.
-        base_path: The Path object to make paths relative to. Required if use_relative is True.
+        base_path: The Path object to make paths relative to. Required if ``use_relative`` is ``True``.
+        console: Optional ``Console`` used for warning messages. If ``None`` a new ``Console`` is created.
 
     Returns:
         A string containing newline-separated file paths, or a message if no paths are found.

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -44,17 +44,21 @@ class TestFormatPaths:
     def test_relative_paths_missing_base_warns_and_falls_back_to_absolute(
         self,
         tmp_path: Path,
-        capsys: pytest.CaptureFixture[str],
     ) -> None:
         file1 = tmp_path / "f1.txt"
         file2 = tmp_path / "f2.txt"
         file1.write_text("1")
         file2.write_text("2")
 
-        test_console = Console()
-        result = format_paths([file1, file2], use_relative=True, base_path=None, console=test_console)
-        captured = capsys.readouterr()
-        assert "base_path was not provided to format_paths" in captured.out
+        test_console = Console(record=True)
+        result = format_paths(
+            [file1, file2],
+            use_relative=True,
+            base_path=None,
+            console=test_console,
+        )
+        output_text = test_console.export_text()
+        assert "base_path was not provided to format_paths" in output_text
 
         expected = "\n".join(
             sorted(


### PR DESCRIPTION
## Summary
- document optional console parameter in formatter
- capture Rich console output in format_paths test

## Testing
- `pytest tests/unit/test_formatter.py::TestFormatPaths::test_relative_paths_missing_base_warns_and_falls_back_to_absolute -q` *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_6845c06d33288333b93ce3e41bdbad10