### PR TITLE
Fix type hints and tests

### DIFF
--- a/simgrep/indexer.py
+++ b/simgrep/indexer.py
@@ -138,7 +138,7 @@ class Indexer:
                     if len(self.usearch_index) > 0:
                         try:
                             max_existing_label = self.usearch_index.keys[len(self.usearch_index.keys) - 1]
-                            self._current_usearch_label = max_existing_label + 1
+                            self._current_usearch_label = int(max_existing_label) + 1
                         except Exception:
                             self.console.print(
                                 "[yellow]Warning: Could not determine max key from existing index,"

--- a/simgrep/main.py
+++ b/simgrep/main.py
@@ -163,12 +163,11 @@ def search(
         resolve_path=True,
         help="The path to a text file or directory for ephemeral search. If omitted, searches the default persistent index.",
     ),
-    patterns: Optional[Tuple[str, ...]] = typer.Option(
+    patterns: Optional[List[str]] = typer.Option(
         None,
         "--pattern",
         "-p",
         help="Glob pattern(s) for files when searching directories. Can be used multiple times. Defaults to '*.txt'.",
-        multiple=True,
     ),
     output: OutputMode = typer.Option(
         OutputMode.show,  # Default output mode

--- a/tests/e2e/test_cli_persistent_e2e.py
+++ b/tests/e2e/test_cli_persistent_e2e.py
@@ -274,8 +274,10 @@ class TestCliPersistentE2E:
 
         db_file = temp_simgrep_home / ".config" / "simgrep" / "default_project" / "metadata.duckdb"
         conn = duckdb.connect(str(db_file))
-        initial_files = conn.execute("SELECT COUNT(*) FROM indexed_files;").fetchone()[0]
+        row_initial = conn.execute("SELECT COUNT(*) FROM indexed_files;").fetchone()
         conn.close()
+        assert row_initial is not None
+        initial_files = row_initial[0]
 
         decline_result = run_simgrep_command(
             ["index", str(sample_docs_dir_session)], env=env_vars, input_str="n\n"
@@ -284,6 +286,8 @@ class TestCliPersistentE2E:
         assert "Aborted" in decline_result.stderr
 
         conn = duckdb.connect(str(db_file))
-        after_files = conn.execute("SELECT COUNT(*) FROM indexed_files;").fetchone()[0]
+        row_after = conn.execute("SELECT COUNT(*) FROM indexed_files;").fetchone()
         conn.close()
+        assert row_after is not None
+        after_files = row_after[0]
         assert after_files == initial_files

--- a/tests/integration/test_indexer_persistent.py
+++ b/tests/integration/test_indexer_persistent.py
@@ -292,38 +292,54 @@ class TestIndexerPersistent:
 
         conn = connect_persistent_db(indexer_config.db_path)
         try:
-            file2_chunks_before = conn.execute(
+            file2_chunks_before_row = conn.execute(
                 "SELECT COUNT(*) FROM text_chunks tc JOIN indexed_files f ON tc.file_id=f.file_id WHERE f.file_path = ?;",
                 [str(file2_path)],
-            ).fetchone()[0]
-            total_chunks_before = conn.execute("SELECT COUNT(*) FROM text_chunks;").fetchone()[0]
-            file2_hash_before = conn.execute(
+            ).fetchone()
+            total_chunks_before_row = conn.execute("SELECT COUNT(*) FROM text_chunks;").fetchone()
+            file2_hash_before_row = conn.execute(
                 "SELECT content_hash FROM indexed_files WHERE file_path = ?;",
                 [str(file2_path)],
-            ).fetchone()[0]
+            ).fetchone()
+            assert file2_chunks_before_row is not None
+            assert total_chunks_before_row is not None
+            assert file2_hash_before_row is not None
+            file2_chunks_before = file2_chunks_before_row[0]
+            total_chunks_before = total_chunks_before_row[0]
+            file2_hash_before = file2_hash_before_row[0]
         finally:
             conn.close()
 
-        index_size_before = len(load_persistent_index(indexer_config.usearch_index_path))
+        idx_before = load_persistent_index(indexer_config.usearch_index_path)
+        assert idx_before is not None
+        index_size_before = len(idx_before)
 
         indexer2 = Indexer(config=indexer_config, console=test_console)
         indexer2.index_path(target_path=sample_files_dir, wipe_existing=False)
 
         conn = connect_persistent_db(indexer_config.db_path)
         try:
-            file2_hash_after = conn.execute(
+            file2_hash_after_row = conn.execute(
                 "SELECT content_hash FROM indexed_files WHERE file_path = ?;",
                 [str(file2_path)],
-            ).fetchone()[0]
-            file2_chunks_after = conn.execute(
+            ).fetchone()
+            file2_chunks_after_row = conn.execute(
                 "SELECT COUNT(*) FROM text_chunks tc JOIN indexed_files f ON tc.file_id=f.file_id WHERE f.file_path = ?;",
                 [str(file2_path)],
-            ).fetchone()[0]
-            total_chunks_nochange = conn.execute("SELECT COUNT(*) FROM text_chunks;").fetchone()[0]
+            ).fetchone()
+            total_chunks_nochange_row = conn.execute("SELECT COUNT(*) FROM text_chunks;").fetchone()
+            assert file2_hash_after_row is not None
+            assert file2_chunks_after_row is not None
+            assert total_chunks_nochange_row is not None
+            file2_hash_after = file2_hash_after_row[0]
+            file2_chunks_after = file2_chunks_after_row[0]
+            total_chunks_nochange = total_chunks_nochange_row[0]
         finally:
             conn.close()
 
-        index_size_nochange = len(load_persistent_index(indexer_config.usearch_index_path))
+        idx_nochange = load_persistent_index(indexer_config.usearch_index_path)
+        assert idx_nochange is not None
+        index_size_nochange = len(idx_nochange)
 
         assert file2_hash_after == file2_hash_before
         assert file2_chunks_after == file2_chunks_before
@@ -338,14 +354,18 @@ class TestIndexerPersistent:
 
         conn = connect_persistent_db(indexer_config.db_path)
         try:
-            new_hash_db = conn.execute(
+            new_hash_row = conn.execute(
                 "SELECT content_hash FROM indexed_files WHERE file_path = ?;",
                 [str(file1_path)],
-            ).fetchone()[0]
-            file2_chunks_after_mod = conn.execute(
+            ).fetchone()
+            file2_chunks_after_mod_row = conn.execute(
                 "SELECT COUNT(*) FROM text_chunks tc JOIN indexed_files f ON tc.file_id=f.file_id WHERE f.file_path = ?;",
                 [str(file2_path)],
-            ).fetchone()[0]
+            ).fetchone()
+            assert new_hash_row is not None
+            assert file2_chunks_after_mod_row is not None
+            new_hash_db = new_hash_row[0]
+            file2_chunks_after_mod = file2_chunks_after_mod_row[0]
         finally:
             conn.close()
 

--- a/tests/unit/test_vector_store.py
+++ b/tests/unit/test_vector_store.py
@@ -36,7 +36,7 @@ class TestCreateInmemoryIndex:
     def test_mismatched_shapes_raises(self) -> None:
         embeddings = np.random.rand(3, 4).astype(np.float32)
         labels = np.array([1, 2], dtype=np.int64)
-        with pytest.raises(ValueError, match="Number of embeddings \(3\) must match number of labels \(2\)"):
+        with pytest.raises(ValueError, match=r"Number of embeddings \(3\) must match number of labels \(2\)"):
             create_inmemory_index(embeddings, labels)
 
     def test_empty_embeddings_raise(self) -> None:


### PR DESCRIPTION
## Summary
- update Typer option for patterns to use list typing
- cast to int when reading existing label from USearch index
- guard DB fetch results in tests
- escape regex in unit test

## Testing
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6845c1762fb4833382a338e738e52a33