### PR TITLE
Add simple positive tests

### DIFF
--- a/tests/integration/test_searcher_persistent_integration.py
+++ b/tests/integration/test_searcher_persistent_integration.py
@@ -288,3 +288,32 @@ class TestSearcherPersistentIntegration:
         )
         out_two = capsys.readouterr().out
         assert out_two.count("---") >= 2
+
+    def test_perform_persistent_search_paths_relative_output(
+        self,
+        populated_persistent_index_for_searcher: Tuple[
+            duckdb.DuckDBPyConnection,
+            usearch.index.Index,
+            SimgrepConfig,
+        ],
+        test_console: Console,
+        capsys: pytest.CaptureFixture,
+        persistent_search_test_data_path: Path,
+    ) -> None:
+        db_conn, vector_index_val, global_cfg = populated_persistent_index_for_searcher
+        query = "semantic search"  # matches file2.txt
+
+        perform_persistent_search(
+            query_text=query,
+            console=test_console,
+            db_conn=db_conn,
+            vector_index=vector_index_val,
+            global_config=global_cfg,
+            output_mode=OutputMode.paths,
+            k_results=2,
+            display_relative_paths=True,
+            base_path_for_relativity=persistent_search_test_data_path,
+            min_score=0.25,
+        )
+        captured = capsys.readouterr()
+        assert "file2.txt" in captured.out

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -3,7 +3,15 @@ from pathlib import Path
 import pytest
 from rich.console import Console
 
-from simgrep.formatter import format_paths
+from simgrep.formatter import format_paths, format_show_basic
+
+
+class TestFormatShowBasic:
+    def test_basic_formatting(self, tmp_path: Path) -> None:
+        file_path = tmp_path / "file.txt"
+        result = format_show_basic(file_path, "snippet", 0.123456)
+        expected = f"File: {str(file_path)}\nScore: 0.1235\nChunk: snippet"
+        assert result == expected
 
 
 class TestFormatPaths:


### PR DESCRIPTION
## Summary
- test basic formatting with `format_show_basic`
- ensure relative path output works for persistent search results

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6845c73628b88333b5359a724b97dbd8