### PR TITLE
Add use case diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ It's designed for ephemeral (one-off) searches and will soon support persistent 
 
 See the [Architecture Document](docs/architecture.md) for more details.
 
+## Use Cases
+See [use-case diagrams](docs/use-cases.md) for ephemeral search, persistent indexing, and RAG-based answering.
+
+
 ## Current Capabilities (Ephemeral Search)
 
 When you run `simgrep "your query" ./path/to/search`:

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,59 @@
+# Use Cases
+
+`simgrep` supports several workflows for searching and answering questions over your local files.
+
+## Ephemeral Search
+
+For one-off queries, `simgrep` creates a temporary index in memory, searches it, then discards it.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User
+    participant simgrep
+    participant USearch
+    participant DuckDB
+    User->>simgrep: simgrep search "query" path
+    simgrep->>DuckDB: store chunks in memory
+    simgrep->>USearch: build in-memory index
+    simgrep->>USearch: query embeddings
+    USearch-->>simgrep: similar chunks
+    simgrep->>User: display results
+```
+
+## Persistent Indexing & Search
+
+Projects can be indexed once and searched many times. Index data is saved on disk.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User
+    participant simgrep
+    participant USearch
+    participant DuckDB
+    User->>simgrep: simgrep index project/
+    simgrep->>USearch: add embeddings to disk
+    simgrep->>DuckDB: record metadata
+    User->>simgrep: simgrep search "query"
+    simgrep->>USearch: lookup embeddings
+    USearch-->>simgrep: results
+    simgrep->>User: show matches
+```
+
+## RAG-Based Answering
+
+`simgrep` can retrieve relevant chunks and feed them to a language model to answer questions.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User
+    participant simgrep
+    participant USearch
+    participant DuckDB
+    User->>simgrep: simgrep answer "question"
+    simgrep->>USearch: retrieve top chunks
+    USearch-->>simgrep: return passages
+    simgrep->>User: final answer (via LLM)
+```


### PR DESCRIPTION
## Summary
- document ephemeral search, persistent indexing & search, and RAG-based answering
- link the new documentation from README

## Testing
- `make test` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6845daaa7c5883338ef9f5fd3222da15