### PR TITLE
Improve test speed by caching model loads

### DIFF
--- a/simgrep/indexer.py
+++ b/simgrep/indexer.py
@@ -31,6 +31,7 @@ from .processor import (
     extract_text_from_file,
     generate_embeddings,
     load_tokenizer,
+    load_embedding_model,
 )
 from .vector_store import load_persistent_index, save_persistent_index
 
@@ -68,11 +69,10 @@ class Indexer:
             raise IndexerError(f"Failed to load tokenizer: {e}") from e
 
         try:
-            self.console.print(f"Loading embedding model: '{self.config.embedding_model_name}'...")
-            # Import SentenceTransformer here or at the top of the file
-            from sentence_transformers import SentenceTransformer
-
-            self.embedding_model: SentenceTransformer = SentenceTransformer(self.config.embedding_model_name)
+            self.console.print(
+                f"Loading embedding model: '{self.config.embedding_model_name}'..."
+            )
+            self.embedding_model = load_embedding_model(self.config.embedding_model_name)
             self.console.print("Embedding model loaded.")
 
             self.console.print("Determining embedding dimension...")

--- a/simgrep/main.py
+++ b/simgrep/main.py
@@ -406,12 +406,17 @@ def search(
 
         try:
             # Load embedding model once for ephemeral search
+            from .processor import load_embedding_model
             from sentence_transformers import SentenceTransformer
 
             embedding_model_instance: Optional[SentenceTransformer] = None
             try:
-                console.print(f"  Loading embedding model '{global_simgrep_config.default_embedding_model_name}'...")
-                embedding_model_instance = SentenceTransformer(global_simgrep_config.default_embedding_model_name)
+                console.print(
+                    f"  Loading embedding model '{global_simgrep_config.default_embedding_model_name}'..."
+                )
+                embedding_model_instance = load_embedding_model(
+                    global_simgrep_config.default_embedding_model_name
+                )
                 console.print("    Embedding model loaded.")
             except Exception as e_model_load:
                 console.print(f"[bold red]Fatal Error: Could not load embedding model.[/bold red]\n  Details: {e_model_load}")

--- a/simgrep/processor.py
+++ b/simgrep/processor.py
@@ -4,6 +4,7 @@ from typing import List, Optional, TypedDict, cast
 
 import numpy as np
 import unstructured.partition.auto as auto_partition
+from functools import lru_cache
 from sentence_transformers import SentenceTransformer
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 from unstructured.documents.elements import Element
@@ -34,10 +35,9 @@ def extract_text_from_file(file_path: Path) -> str:
         raise RuntimeError(f"Failed to extract text from {file_path}") from e
 
 
+@lru_cache(maxsize=None)
 def load_tokenizer(model_name: str) -> PreTrainedTokenizerBase:
-    """
-    Loads a Hugging Face tokenizer.
-    """
+    """Load and cache a Hugging Face tokenizer."""
     try:
         tokenizer = AutoTokenizer.from_pretrained(model_name)
         return cast(PreTrainedTokenizerBase, tokenizer)
@@ -45,7 +45,18 @@ def load_tokenizer(model_name: str) -> PreTrainedTokenizerBase:
         raise RuntimeError(
             f"Failed to load tokenizer for model '{model_name}'. "
             "Ensure the model name is correct and an internet connection "
-            "is available for the first download. Original error: {e}"
+            f"is available for the first download. Original error: {e}"
+        ) from e
+
+
+@lru_cache(maxsize=None)
+def load_embedding_model(model_name: str) -> SentenceTransformer:
+    """Load and cache a sentence-transformer model."""
+    try:
+        return SentenceTransformer(model_name)
+    except Exception as e:
+        raise RuntimeError(
+            f"Failed to load embedding model '{model_name}'. Original error: {e}"
         ) from e
 
 


### PR DESCRIPTION
## Summary
- cache HuggingFace tokenizers and sentence transformers
- use cached loaders in `Indexer` and CLI

## Testing
- `make test` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6845f35bf4d883339b7dfdadd7781fa6