### PR TITLE
Add coverage to local test run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,15 @@ jobs:
 
       - name: Run tests
         run: make test
+
+      - name: Upload pytest results
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-results
+          path: reports/junit.xml
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,11 @@ format-check:
 	$(UV) run ruff format --check .
 
 test:
-    @echo "Running tests (Pytest with coverage)..."
-    mkdir -p reports
-    $(UV) run pytest -n auto \
-        --junitxml=reports/junit.xml \
-        --cov=simgrep --cov-report=xml
+	@echo "Running tests (Pytest with coverage)..."
+	mkdir -p reports
+	$(UV) run pytest -n auto \
+	    --junitxml=reports/junit.xml \
+	    --cov=simgrep --cov-report=xml
 
 typecheck:
 	@echo "Running static type checker (Mypy)..."

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,11 @@ format-check:
 	$(UV) run ruff format --check .
 
 test:
-	@echo "Running tests (Pytest in parallel)..."
-	$(UV) run pytest -n auto
+    @echo "Running tests (Pytest with coverage)..."
+    mkdir -p reports
+    $(UV) run pytest -n auto \
+        --junitxml=reports/junit.xml \
+        --cov=simgrep --cov-report=xml
 
 typecheck:
 	@echo "Running static type checker (Mypy)..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev-dependencies = [
     "pytest-timeout>=2.3.0",
     "pytest-xdist>=3.5.0",
     "hypothesis>=6.100",
+    "pytest-cov>=6.0",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary
- run pytest with coverage via Makefile so CI and local commands match
- call `make test` in CI workflow

## Testing
- `make install` *(success)*
- `make download-models` *(success)*
- `make test` *(failed: Plugin raised an exception during teardown)*

------
https://chatgpt.com/codex/tasks/task_e_6845f602af248333a10346c2cd583a20