### PR TITLE
Add persistent global config with project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "usearch>=2.9.0",
     "numpy>=1.23.0",
     "duckdb>=0.10.0",
+    "tomli_w>=1.0.0",
 ]
 
 [project.scripts]

--- a/simgrep/config.py
+++ b/simgrep/config.py
@@ -1,9 +1,13 @@
 import sys  # for printing to stderr
+from pathlib import Path
+import tomllib
+
+import tomli_w
 
 try:
-    from .models import SimgrepConfig
+    from .models import ProjectConfig, SimgrepConfig
 except ImportError:
-    from simgrep.models import SimgrepConfig
+    from simgrep.models import ProjectConfig, SimgrepConfig
 
 
 # default number of top results to fetch for searches
@@ -31,19 +35,72 @@ def load_or_create_global_config() -> SimgrepConfig:
     """
     config = SimgrepConfig()
 
-    # ensure the data directory for the default project exists
+    # ensure directories exist
     try:
-        # config.default_project_data_dir is, e.g., ~/.config/simgrep/default_project
-        # mkdir(parents=true) will create ~/.config/simgrep/ as well if it doesn't exist.
+        config.db_directory.mkdir(parents=True, exist_ok=True)
         config.default_project_data_dir.mkdir(parents=True, exist_ok=True)
     except OSError as e:
         error_message = (
-            f"Fatal: Could not create simgrep data directory at "
-            f"'{config.default_project_data_dir}'. Please check permissions. Error: {e}"
+            f"Fatal: Could not create simgrep data directory at '{config.default_project_data_dir}'. "
+            f"Please check permissions. Error: {e}"
         )
-        # for now, print to stderr and raise a custom error.
-        # in a more mature cli, rich console might be used here.
         print(error_message, file=sys.stderr)
         raise SimgrepConfigError(error_message) from e
 
+    if config.config_file.exists():
+        with open(config.config_file, "rb") as f:
+            data = tomllib.load(f)
+        config = SimgrepConfig(**data)
+        default_proj = config.projects.get("default")
+        if default_proj is None:
+            default_proj = _create_default_project(config)
+            config.projects["default"] = default_proj
+            _write_config(config)
+    else:
+        default_proj = _create_default_project(config)
+        config.projects = {"default": default_proj}
+        _write_config(config)
+
+    from .metadata_db import connect_global_db, get_project_by_name, insert_project
+
+    global_db_path = config.db_directory / "global_metadata.duckdb"
+    conn = connect_global_db(global_db_path)
+    try:
+        if get_project_by_name(conn, "default") is None:
+            insert_project(
+                conn,
+                project_name="default",
+                db_path=str(default_proj.db_path),
+                usearch_index_path=str(default_proj.usearch_index_path),
+                embedding_model_name=default_proj.embedding_model,
+            )
+    finally:
+        conn.close()
+
     return config
+
+
+def _serialize_paths(obj):
+    if isinstance(obj, Path):
+        return str(obj)
+    if isinstance(obj, dict):
+        return {k: _serialize_paths(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_serialize_paths(v) for v in obj]
+    return obj
+
+
+def _write_config(config: SimgrepConfig) -> None:
+    data = _serialize_paths(config.model_dump())
+    with open(config.config_file, "wb") as f:
+        tomli_w.dump(data, f)
+
+
+def _create_default_project(config: SimgrepConfig):
+    return ProjectConfig(
+        name="default",
+        indexed_paths=[],
+        embedding_model=config.default_embedding_model_name,
+        db_path=config.default_project_data_dir / "metadata.duckdb",
+        usearch_index_path=config.default_project_data_dir / "index.usearch",
+    )

--- a/simgrep/models.py
+++ b/simgrep/models.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from pathlib import Path
+from typing import Dict, List
 
 from pydantic import BaseModel, Field
 
@@ -28,6 +29,14 @@ class ChunkData(BaseModel):
     token_count: int  # number of tokens in this chunk (as per the specified tokenizer)
 
 
+class ProjectConfig(BaseModel):
+    name: str
+    indexed_paths: List[Path] = Field(default_factory=list)
+    embedding_model: str
+    db_path: Path
+    usearch_index_path: Path
+
+
 class SimgrepConfig(BaseModel):
     """
     Global configuration for simgrep.
@@ -41,6 +50,16 @@ class SimgrepConfig(BaseModel):
     default_project_data_dir: Path = Field(
         default_factory=lambda: Path("~/.config/simgrep/default_project").expanduser()
     )
+
+    config_file: Path = Field(
+        default_factory=lambda: Path("~/.config/simgrep/config.toml").expanduser()
+    )
+
+    db_directory: Path = Field(
+        default_factory=lambda: Path("~/.config/simgrep").expanduser()
+    )
+
+    projects: Dict[str, ProjectConfig] = Field(default_factory=dict)
 
     # centralizing other global defaults from main.py constants / architecture doc:
     # these will be used by persistent indexing logic in later deliverables (e.g., 3.3, 3.4).

--- a/tests/integration/test_global_config.py
+++ b/tests/integration/test_global_config.py
@@ -1,0 +1,27 @@
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from simgrep.config import load_or_create_global_config
+from simgrep.metadata_db import connect_global_db, get_project_by_name
+
+
+def test_default_project_exists_in_global_db(tmp_path: Path) -> None:
+    user_home = tmp_path / "home"
+    user_home.mkdir()
+
+    def mock_expand(path_str: str) -> str:
+        if path_str == "~" or path_str.startswith("~/"):
+            return path_str.replace("~", str(user_home), 1)
+        return os.path.expanduser(path_str)
+
+    with patch("os.path.expanduser", side_effect=mock_expand):
+        cfg = load_or_create_global_config()
+        global_db_path = cfg.db_directory / "global_metadata.duckdb"
+        conn = connect_global_db(global_db_path)
+        try:
+            project = get_project_by_name(conn, "default")
+            assert project is not None
+        finally:
+            conn.close()
+


### PR DESCRIPTION
## Summary
- define `ProjectConfig` and extend `SimgrepConfig`
- load and write `config.toml` with default project
- create global metadata database storing project info
- bootstrap default project on first run
- test config creation and global DB initialization

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684602eacd9483339f9fff742e1e0d7f