### PR TITLE
Improve test coverage

### DIFF
--- a/tests/property/test_vector_store_property.py
+++ b/tests/property/test_vector_store_property.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from hypothesis import given, strategies as st
+from hypothesis import HealthCheck, given, settings, strategies as st
 from hypothesis.extra import numpy as hynp
 
 pytest.importorskip("numpy")
@@ -30,6 +30,7 @@ def _embedding_label_strategy():
     return _inner()
 
 
+@settings(deadline=None, suppress_health_check=[HealthCheck.too_slow])
 @given(_embedding_label_strategy())
 def test_search_results_subset_and_len(data: tuple[np.ndarray, np.ndarray, np.ndarray]) -> None:
     embeddings, labels, query = data

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -77,3 +77,13 @@ class TestFormatPaths:
             )
         )
         assert result == expected
+
+    def test_relative_paths_outside_base_fallbacks_to_absolute(self, tmp_path: Path) -> None:
+        base_path = tmp_path / "base"
+        base_path.mkdir()
+        outside_file = tmp_path / "outside.txt"
+        outside_file.write_text("x")
+
+        result = format_paths([outside_file], use_relative=True, base_path=base_path)
+
+        assert result == str(outside_file.resolve())


### PR DESCRIPTION
## Summary
- add Hypothesis settings to stabilize property tests
- add test for relative path fallback when file is outside base directory

## Testing
- `make test` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68460384f00483339ec48ab9492ca964