### PR TITLE
Add missing format_paths empty list test

### DIFF
--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -87,3 +87,7 @@ class TestFormatPaths:
         result = format_paths([outside_file], use_relative=True, base_path=base_path)
 
         assert result == str(outside_file.resolve())
+
+    def test_empty_paths_returns_no_matches_message(self) -> None:
+        result = format_paths([], use_relative=False, base_path=None)
+        assert result == "No matching files found."


### PR DESCRIPTION
## Summary
- expand formatter unit tests with case for empty input list

## Testing
- `pytest tests/unit/test_formatter.py::TestFormatPaths::test_empty_paths_returns_no_matches_message -vv`
- `make test` *(fails: KeyboardInterrupt when running full test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68460e77b74c8333990e713e10f657cc