### PR TITLE
Add relative path e2e tests

### DIFF
--- a/tests/e2e/test_cli_ephemeral_e2e.py
+++ b/tests/e2e/test_cli_ephemeral_e2e.py
@@ -49,3 +49,28 @@ class TestCliEphemeralE2E:
         assert "single.txt" in result.stdout
         assert "Processing:" in result.stdout
         assert "100%" in result.stdout
+
+    def test_ephemeral_search_relative_paths(self, tmp_path: pathlib.Path, temp_simgrep_home: pathlib.Path) -> None:
+        docs_dir = tmp_path / "docs_rel"
+        docs_dir.mkdir()
+        (docs_dir / "root.txt").write_text("apples here")
+        subdir = docs_dir / "subdir"
+        subdir.mkdir()
+        (subdir / "nested.txt").write_text("more apples")
+
+        env_vars = {"HOME": str(temp_simgrep_home)}
+
+        result = run_simgrep_command(
+            [
+                "search",
+                "apples",
+                str(docs_dir),
+                "--output",
+                "paths",
+                "--relative-paths",
+            ],
+            env=env_vars,
+        )
+        assert result.returncode == 0
+        assert "root.txt" in result.stdout
+        assert "subdir/nested.txt" in result.stdout

--- a/tests/e2e/test_cli_persistent_e2e.py
+++ b/tests/e2e/test_cli_persistent_e2e.py
@@ -307,3 +307,24 @@ class TestCliPersistentE2E:
         assert row_after is not None
         after_files = row_after[0]
         assert after_files == initial_files
+
+    def test_persistent_search_relative_paths(
+        self, temp_simgrep_home: pathlib.Path, sample_docs_dir_session: pathlib.Path
+    ) -> None:
+        env_vars = {"HOME": str(temp_simgrep_home)}
+
+        run_simgrep_command(
+            ["index", str(sample_docs_dir_session), "--rebuild"],
+            env=env_vars,
+            input_str="y\n",
+        )
+
+        search_result = run_simgrep_command(
+            ["search", "apples", "--output", "paths", "--relative-paths"],
+            env=env_vars,
+            cwd=sample_docs_dir_session,
+        )
+        assert search_result.returncode == 0
+        assert "doc1.txt" in search_result.stdout
+        assert "subdir/doc_sub.txt" in search_result.stdout
+        assert str(sample_docs_dir_session) not in search_result.stdout


### PR DESCRIPTION
## Summary
- expand CLI e2e suite with tests for `--relative-paths`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68460f27cf708333b6e39e95be856355