### PR TITLE
Add extra tests for utils and searcher

### DIFF
--- a/tests/unit/test_main_patterns.py
+++ b/tests/unit/test_main_patterns.py
@@ -19,3 +19,32 @@ class TestGatherFilesToProcess:
         file_csv.write_text("C")
         result = gather_files_to_process(tmp_path, ["*.txt", "*.md"])
         assert set(result) == {file_txt.resolve(), file_md.resolve()}
+
+    def test_path_is_file(self, tmp_path: Path) -> None:
+        file_path = tmp_path / "only.txt"
+        file_path.write_text("X")
+        result = gather_files_to_process(file_path, ["*.txt"])
+        assert result == [file_path.resolve()]
+
+    def test_nested_directories(self, tmp_path: Path) -> None:
+        sub = tmp_path / "sub" / "nested"
+        sub.mkdir(parents=True)
+        f1 = sub / "a.txt"
+        f2 = sub / "b.md"
+        f1.write_text("1")
+        f2.write_text("2")
+        result = gather_files_to_process(tmp_path, ["*.txt", "*.md"])
+        assert set(result) == {f1.resolve(), f2.resolve()}
+
+    def test_no_matching_files(self, tmp_path: Path) -> None:
+        (tmp_path / "a.txt").write_text("A")
+        result = gather_files_to_process(tmp_path, ["*.md"])
+        assert result == []
+
+    def test_deduplicate_and_sort(self, tmp_path: Path) -> None:
+        f1 = tmp_path / "c.txt"
+        f2 = tmp_path / "b.txt"
+        f1.write_text("1")
+        f2.write_text("2")
+        result = gather_files_to_process(tmp_path, ["*.txt", "c.*", "*.txt"])
+        assert result == [f2.resolve(), f1.resolve()]

--- a/tests/unit/test_searcher.py
+++ b/tests/unit/test_searcher.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pathlib
 import pytest
 from rich.console import Console
 
@@ -36,3 +37,98 @@ def test_perform_persistent_search_no_results(monkeypatch: pytest.MonkeyPatch, c
 
     out = capsys.readouterr().out
     assert "No relevant chunks found in the persistent index." in out
+
+class DummyStore:
+    def __init__(self, mapping):
+        self.mapping = mapping
+    def retrieve_chunk_details_persistent(self, label: int):
+        return self.mapping.get(label)
+
+
+def test_perform_persistent_search_show_results(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    console = Console()
+    store = DummyStore({1: ("hello", pathlib.Path("a.txt"), 0, 5)})
+
+    def fake_generate_embeddings(texts: list[str], model_name: str):
+        return np.zeros((1, 3), dtype=np.float32)
+
+    def fake_search_inmemory_index(index: object, query_embedding: np.ndarray, k: int = 5):
+        return [(1, 0.95)]
+
+    monkeypatch.setattr(searcher, "generate_embeddings", fake_generate_embeddings)
+    monkeypatch.setattr(searcher, "search_inmemory_index", fake_search_inmemory_index)
+
+    searcher.perform_persistent_search(
+        query_text="hello",
+        console=console,
+        metadata_store=store,
+        vector_index=object(),
+        global_config=SimgrepConfig(),
+        output_mode=OutputMode.show,
+        min_score=0.5,
+    )
+
+    out = capsys.readouterr().out
+    assert "Search Results" in out
+    assert "hello" in out
+
+
+def test_perform_persistent_search_paths_output(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    console = Console()
+    store = DummyStore({1: ("t1", pathlib.Path("a.txt"), 0, 1), 2: ("t2", pathlib.Path("b.txt"), 1, 2)})
+
+    def fake_generate_embeddings(texts: list[str], model_name: str):
+        return np.zeros((1, 3), dtype=np.float32)
+
+    def fake_search_inmemory_index(index: object, query_embedding: np.ndarray, k: int = 5):
+        return [(1, 0.9), (2, 0.8), (1, 0.7)]
+
+    monkeypatch.setattr(searcher, "generate_embeddings", fake_generate_embeddings)
+    monkeypatch.setattr(searcher, "search_inmemory_index", fake_search_inmemory_index)
+
+    searcher.perform_persistent_search(
+        query_text="query",
+        console=console,
+        metadata_store=store,
+        vector_index=object(),
+        global_config=SimgrepConfig(),
+        output_mode=OutputMode.paths,
+        min_score=0.5,
+    )
+
+    out = capsys.readouterr().out
+    assert "a.txt" in out
+    assert "b.txt" in out
+    assert out.strip().splitlines().count("a.txt") == 1
+
+
+def test_perform_persistent_search_metadata_error(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    console = Console()
+
+    class ErrorStore:
+        def retrieve_chunk_details_persistent(self, label: int):
+            raise searcher.MetadataDBError("boom")
+
+    store = ErrorStore()
+
+    def fake_generate_embeddings(texts: list[str], model_name: str):
+        return np.zeros((1, 3), dtype=np.float32)
+
+    def fake_search_inmemory_index(index: object, query_embedding: np.ndarray, k: int = 5):
+        return [(1, 0.95)]
+
+    monkeypatch.setattr(searcher, "generate_embeddings", fake_generate_embeddings)
+    monkeypatch.setattr(searcher, "search_inmemory_index", fake_search_inmemory_index)
+
+    searcher.perform_persistent_search(
+        query_text="query",
+        console=console,
+        metadata_store=store,
+        vector_index=object(),
+        global_config=SimgrepConfig(),
+        output_mode=OutputMode.show,
+        min_score=0.5,
+    )
+
+    out = capsys.readouterr().out
+    assert "Database error" in out


### PR DESCRIPTION
## Summary
- extend `TestGatherFilesToProcess` with more scenarios
- add path and error handling tests for `perform_persistent_search`

## Testing
- `make test` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684614677c74833388ef4e17f7f75a07