### PR TITLE
Allow creation of empty USearch index

### DIFF
--- a/simgrep/vector_store.py
+++ b/simgrep/vector_store.py
@@ -61,21 +61,8 @@ def create_inmemory_index(
     if embeddings.shape[0] > 0:
         num_dimensions = embeddings.shape[1]
     else:
-        # cannot infer dimensions from empty embeddings.
-        # this case should be handled by the caller providing ndim if creating an empty index
-        # or by usearch having a default. for now, let's raise if empty and no explicit ndim.
-        # however, the function signature doesn't take ndim.
-        # let's assume if embeddings are empty, we create an index that can be added to later.
-        # usearch requires ndim at initialization.
-        # this function is for *populating* an index. if embeddings are empty,
-        # the caller should perhaps create an empty index differently.
-        # for now, if `embeddings` is empty, we'll assume the caller knows `ndim` isn't derived.
-        # this function is primarily for when embeddings *exist*.
-        # let's stick to the original logic: if embeddings are empty, raise valueerror.
-        if embeddings.shape[0] == 0:
-            raise ValueError(
-                "Embeddings array cannot be empty when creating an index that infers ndim."
-            )
+        # embeddings are empty but we can still infer the dimensionality from the
+        # second dimension of the array and create an empty index.
         num_dimensions = embeddings.shape[1]
 
     logger.info(

--- a/tests/unit/test_vector_store.py
+++ b/tests/unit/test_vector_store.py
@@ -39,11 +39,13 @@ class TestCreateInmemoryIndex:
         with pytest.raises(ValueError, match=r"Number of embeddings \(3\) must match number of labels \(2\)"):
             create_inmemory_index(embeddings, labels)
 
-    def test_empty_embeddings_raise(self) -> None:
+    def test_empty_embeddings_allowed(self) -> None:
         embeddings = np.empty((0, 5), dtype=np.float32)
         labels = np.empty((0,), dtype=np.int64)
-        with pytest.raises(ValueError, match="Embeddings array cannot be empty"):
-            create_inmemory_index(embeddings, labels)
+        index = create_inmemory_index(embeddings, labels)
+        assert isinstance(index, usearch.index.Index)
+        assert len(index) == 0
+        assert index.ndim == 5
 
 
 class TestSearchInmemoryIndex:


### PR DESCRIPTION
## Summary
- allow `create_inmemory_index` to build an index even when `embeddings` is empty
- update unit test to expect empty embedding arrays to succeed

## Testing
- `uv run pytest -n auto tests/unit/test_vector_store.py`
- ❌ `make test` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68468ff1945483339398ed815e178649