### PR TITLE
Switch vector search to dataclass results

### DIFF
--- a/simgrep/main.py
+++ b/simgrep/main.py
@@ -38,7 +38,7 @@ try:
         insert_project,
     )
     from .metadata_store import MetadataStore
-    from .models import ChunkData, OutputMode, SimgrepConfig  # OutputMode moved here
+    from .models import ChunkData, OutputMode, SearchResult, SimgrepConfig  # OutputMode moved here
     from .processor import (
         ProcessedChunkInfo,
         chunk_text_by_tokens,
@@ -78,7 +78,7 @@ except ImportError:
             insert_project,
         )
         from simgrep.metadata_store import MetadataStore
-        from simgrep.models import ChunkData, OutputMode, SimgrepConfig
+        from simgrep.models import ChunkData, OutputMode, SearchResult, SimgrepConfig
         from simgrep.processor import (
             ProcessedChunkInfo,
             chunk_text_by_tokens,
@@ -466,7 +466,7 @@ def search(
 
         # --- In-Memory Vector Search ---
         console.print("\n[bold]Step 4: Performing In-Memory Vector Search[/bold]")
-        search_matches: List[Tuple[int, float]] = []
+        search_matches: List[SearchResult] = []
 
         if chunk_embeddings.size == 0 or chunk_embeddings.shape[0] == 0:
             console.print("  No chunk embeddings available. Skipping vector search.")
@@ -517,7 +517,8 @@ def search(
         else:
             if output == OutputMode.paths:
                 paths_from_matches: List[Path] = []
-                for matched_chunk_id, _similarity_score in search_matches:
+                for result in search_matches:
+                    matched_chunk_id = result.label
                     assert store is not None
                     retrieved_details = store.retrieve_chunk_for_display(matched_chunk_id)
                     if retrieved_details:
@@ -546,7 +547,9 @@ def search(
 
             elif output == OutputMode.show:
                 console.print(f"\n[bold cyan]Search Results (Top {len(search_matches)}):[/bold cyan]")
-                for matched_chunk_id, similarity_score in search_matches:
+                for result in search_matches:
+                    matched_chunk_id = result.label
+                    similarity_score = result.score
                     assert store is not None
                     retrieved_details = store.retrieve_chunk_for_display(matched_chunk_id)
 

--- a/simgrep/models.py
+++ b/simgrep/models.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Dict, List
@@ -27,6 +28,12 @@ class ChunkData(BaseModel):
         int  # character offset of the chunk's end in the original file content
     )
     token_count: int  # number of tokens in this chunk (as per the specified tokenizer)
+
+
+@dataclass
+class SearchResult:
+    label: int
+    score: float
 
 
 class ProjectConfig(BaseModel):

--- a/simgrep/vector_store.py
+++ b/simgrep/vector_store.py
@@ -1,15 +1,17 @@
 import logging
 import os
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Union
 
 import numpy as np
 import usearch.index
 
 try:
     from .exceptions import VectorStoreError
-except ImportError:
+    from .models import SearchResult
+except ImportError:  # pragma: no cover - fallback for direct execution
     from simgrep.exceptions import VectorStoreError  # type: ignore
+    from simgrep.models import SearchResult  # type: ignore
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +106,7 @@ def create_inmemory_index(
 
 def search_inmemory_index(
     index: usearch.index.Index, query_embedding: np.ndarray, k: int = 5
-) -> List[Tuple[int, float]]:
+) -> List[SearchResult]:
     """
     Searches an in-memory USearch index for the top-k most similar vectors.
 
@@ -158,7 +160,7 @@ def search_inmemory_index(
         logger.error(f"USearch search operation failed: {e}")
         raise VectorStoreError("USearch search operation failed") from e
 
-    results: List[Tuple[int, float]] = []
+    results: List[SearchResult] = []
     actual_keys: Optional[np.ndarray] = None
     actual_distances: Optional[np.ndarray] = None
     num_found_for_query: int = 0
@@ -208,7 +210,7 @@ def search_inmemory_index(
                     f"Unknown metric '{index.metric}' for similarity conversion. Returning raw negative distance."
                 )
                 similarity = -distance  # default to negative distance if metric unknown
-            results.append((key, similarity))
+            results.append(SearchResult(label=key, score=similarity))
     else:
         logger.info("No matches found by USearch for the query.")
 

--- a/tests/property/test_vector_store_property.py
+++ b/tests/property/test_vector_store_property.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
-from hypothesis import HealthCheck, given, settings, strategies as st
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
 from hypothesis.extra import numpy as hynp
 
 pytest.importorskip("numpy")
@@ -38,7 +39,7 @@ def test_search_results_subset_and_len(data: tuple[np.ndarray, np.ndarray, np.nd
     index = create_inmemory_index(embeddings, labels)
     results = search_inmemory_index(index, query, k=5)
 
-    result_keys = {key for key, _ in results}
+    result_keys = {res.label for res in results}
 
     assert result_keys.issubset(set(labels.tolist()))
     assert len(results) <= 5

--- a/tests/unit/test_searcher.py
+++ b/tests/unit/test_searcher.py
@@ -3,7 +3,7 @@ import pytest
 from rich.console import Console
 
 from simgrep import searcher
-from simgrep.models import OutputMode, SimgrepConfig
+from simgrep.models import OutputMode, SearchResult, SimgrepConfig
 
 
 class MinimalStore:
@@ -19,7 +19,7 @@ def test_perform_persistent_search_no_results(monkeypatch: pytest.MonkeyPatch, c
         return np.zeros((1, 3), dtype=np.float32)
 
     def fake_search_inmemory_index(index: object, query_embedding: np.ndarray, k: int = 5):
-        return [(1, 0.05)]
+        return [SearchResult(label=1, score=0.05)]
 
     monkeypatch.setattr(searcher, "generate_embeddings", fake_generate_embeddings)
     monkeypatch.setattr(searcher, "search_inmemory_index", fake_search_inmemory_index)

--- a/tests/unit/test_vector_store.py
+++ b/tests/unit/test_vector_store.py
@@ -5,6 +5,7 @@ import usearch.index
 pytest.importorskip("numpy")
 pytest.importorskip("usearch.index")
 
+from simgrep.models import SearchResult
 from simgrep.vector_store import create_inmemory_index, search_inmemory_index
 
 
@@ -53,8 +54,9 @@ class TestSearchInmemoryIndex:
         results = search_inmemory_index(index, query, k=2)
 
         assert results
-        assert results[0][0] == simple_labels[0]
-        assert pytest.approx(1.0, abs=1e-5) == results[0][1]
+        assert isinstance(results[0], SearchResult)
+        assert results[0].label == simple_labels[0]
+        assert pytest.approx(1.0, abs=1e-5) == results[0].score
         assert len(results) <= 2
 
     def test_dimension_mismatch_errors(self, simple_embeddings: np.ndarray, simple_labels: np.ndarray) -> None:


### PR DESCRIPTION
## Summary
- add `SearchResult` dataclass for typed search results
- return `List[SearchResult]` from `search_inmemory_index`
- adjust `perform_persistent_search` and the CLI to use the dataclass
- update tests expecting tuple search results

## Testing
- `ruff check simgrep tests`
- `make test` *(fails: KeyboardInterrupt during pytest)*

------
https://chatgpt.com/codex/tasks/task_e_684694c0c4ec8333965d27b2351c038a