### PR TITLE
Update persistent index saving

### DIFF
--- a/simgrep/indexer.py
+++ b/simgrep/indexer.py
@@ -413,9 +413,18 @@ class Indexer:
 
             # finalization
             if self.usearch_index is not None and len(self.usearch_index) > 0:
-                self.console.print(f"Saving vector index with {len(self.usearch_index)} items...")
-                save_persistent_index(self.usearch_index, self.config.usearch_index_path)
-                self.console.print("Vector index saved.")
+                self.console.print(
+                    f"Saving vector index with {len(self.usearch_index)} items..."
+                )
+                saved = save_persistent_index(
+                    self.usearch_index, self.config.usearch_index_path
+                )
+                if saved:
+                    self.console.print("Vector index saved.")
+                else:
+                    self.console.print(
+                        f"[yellow]Failed to save vector index to {self.config.usearch_index_path}[/yellow]"
+                    )
             elif self.usearch_index is not None and len(self.usearch_index) == 0:
                 self.console.print("Vector index is empty. Not saving.")
                 # optionally delete an old index file if it exists and current one is empty after wipe

--- a/simgrep/vector_store.py
+++ b/simgrep/vector_store.py
@@ -235,61 +235,37 @@ def load_persistent_index(index_path: Path) -> Optional[usearch.index.Index]:
         return None
 
 
-def save_persistent_index(index: usearch.index.Index, index_path: Path) -> None:
-    """
-    Saves a USearch index to a file atomically.
+
+def save_persistent_index(index: usearch.index.Index, index_path: Path) -> bool:
+    """Save ``index`` to ``index_path`` atomically.
 
     Args:
-        index: The usearch.index.Index object to save.
-        index_path: The target path to save the index file.
+        index: The :class:`usearch.index.Index` instance to save.
+        index_path: Destination path for the persistent index file.
 
-    Raises:
-        VectorStoreError: If saving fails.
+    Returns:
+        ``True`` if the index was saved successfully, ``False`` if any
+        exception was caught. Errors are logged and suppressed.
     """
+
     logger.info(
         f"Attempting to save USearch index with {len(index)} items to {index_path}"
     )
-    try:
-        index_path.parent.mkdir(parents=True, exist_ok=True)
-        logger.debug(f"Ensured directory exists for USearch index: {index_path.parent}")
-    except OSError as e:
-        logger.error(
-            f"Failed to create directory for USearch index at {index_path.parent}: {e}"
-        )
-        raise VectorStoreError(
-            f"Could not create directory for USearch index at {index_path.parent}"
-        ) from e
 
     temp_index_path = index_path.with_suffix(index_path.suffix + ".tmp")
 
-    # step 1: save to temporary file
     try:
+        index_path.parent.mkdir(parents=True, exist_ok=True)
+        logger.debug(
+            f"Ensured directory exists for USearch index: {index_path.parent}"
+        )
+
         logger.info(f"Saving USearch index to temporary file {temp_index_path}")
         index.save(str(temp_index_path))
         logger.info(
             f"Successfully saved USearch index to temporary file {temp_index_path}"
         )
-    except Exception as e_save:  # catch errors specifically from index.save()
-        logger.error(
-            f"Failed to save USearch index to temporary file {temp_index_path}: {e_save}"
-        )
-        if temp_index_path.exists():
-            try:
-                temp_index_path.unlink()
-                logger.debug(
-                    f"Cleaned up temporary index file {temp_index_path} after save failure."
-                )
-            except OSError as e_unlink_save_fail:
-                logger.error(
-                    f"Failed to clean up temporary index file {temp_index_path} "
-                    f"after save failure: {e_unlink_save_fail}"
-                )
-        raise VectorStoreError(
-            f"Failed to save index to temporary file {temp_index_path}"
-        ) from e_save
 
-    # step 2: atomic move (only if save to temp succeeded)
-    try:
         logger.info(
             f"Attempting to atomically move temporary index from {temp_index_path} to {index_path}"
         )
@@ -297,35 +273,18 @@ def save_persistent_index(index: usearch.index.Index, index_path: Path) -> None:
         logger.info(
             f"Atomically moved temporary index from {temp_index_path} to {index_path}"
         )
-    except OSError as e_move:
-        logger.error(
-            f"Failed to move temporary index {temp_index_path} to {index_path}: {e_move}"
-        )
-        # temp file still exists here, cleanup is important
-        if temp_index_path.exists():
-            try:
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to save USearch index to {index_path}: {e}")
+        try:
+            if temp_index_path.exists():
                 temp_index_path.unlink()
                 logger.debug(
-                    f"Cleaned up temporary index file {temp_index_path} after move failure."
+                    f"Cleaned up temporary index file {temp_index_path} after failure."
                 )
-            except OSError as e_unlink_move_fail:
-                logger.error(
-                    f"Failed to clean up temporary index file {temp_index_path} "
-                    f"after move failure: {e_unlink_move_fail}"
-                )
-        raise VectorStoreError(
-            f"Failed to finalize saving index to {index_path}"
-        ) from e_move
-    finally:
-        # final check for temp file, in case an error occurred before os.replace but after save,
-        # or if an unexpected error (not oserror from replace, not exception from save) occurred.
-        if temp_index_path.exists():
-            try:
-                temp_index_path.unlink()
-                logger.warning(
-                    f"Lingering temporary index file {temp_index_path} found and removed in finally block."
-                )
-            except OSError as e_unlink_final:
-                logger.error(
-                    f"Failed to clean up lingering temporary index file {temp_index_path} in finally block: {e_unlink_final}"
-                )
+        except OSError as cleanup_err:
+            logger.error(
+                f"Failed to clean up temporary index file {temp_index_path}: {cleanup_err}"
+            )
+        return False

--- a/tests/unit/test_vector_store_persistent.py
+++ b/tests/unit/test_vector_store_persistent.py
@@ -49,7 +49,8 @@ class TestPersistentVectorStore:
         assert not persistent_index_path.exists()
         assert not persistent_index_path.parent.exists()  # to check directory creation
 
-        save_persistent_index(sample_usearch_index, persistent_index_path)
+        saved = save_persistent_index(sample_usearch_index, persistent_index_path)
+        assert saved is True
 
         assert persistent_index_path.exists()
         assert persistent_index_path.is_file()
@@ -89,7 +90,8 @@ class TestPersistentVectorStore:
         persistent_index_path: pathlib.Path,
     ) -> None:
         """test saving an empty index."""
-        save_persistent_index(empty_usearch_index, persistent_index_path)
+        saved = save_persistent_index(empty_usearch_index, persistent_index_path)
+        assert saved is True
         assert persistent_index_path.exists()
 
         loaded_index = load_persistent_index(persistent_index_path)
@@ -119,9 +121,9 @@ class TestPersistentVectorStore:
         )  # e.g., .../persistent_indexes/
         path_that_should_be_dir.touch()  # create it as a file
 
-        error_match = f"Could not create directory for USearch index at {str(path_that_should_be_dir)}"
-        with pytest.raises(VectorStoreError, match=error_match):
-            save_persistent_index(sample_usearch_index, persistent_index_path)
+        saved = save_persistent_index(sample_usearch_index, persistent_index_path)
+        assert saved is False
+        assert not persistent_index_path.exists()
 
     def test_save_persistent_index_atomic_failure_on_replace(
         self,
@@ -143,11 +145,8 @@ class TestPersistentVectorStore:
 
         # the error message comes from the inner try-except block handling os.replace failure.
         # it should indicate failure to finalize the move to the persistent_index_path.
-        expected_error_message = (
-            f"Failed to finalize saving index to {str(persistent_index_path)}"
-        )
-        with pytest.raises(VectorStoreError, match=expected_error_message):
-            save_persistent_index(sample_usearch_index, persistent_index_path)
+        saved = save_persistent_index(sample_usearch_index, persistent_index_path)
+        assert saved is False
 
         # final state: original file should not exist, temp file should be cleaned up
         assert not persistent_index_path.exists()


### PR DESCRIPTION
## Summary
- `save_persistent_index` now returns a boolean and never raises
- adjust `Indexer.index_path` to log failure when saving the index
- update unit tests to check the boolean return value

## Testing
- `make test` *(fails: environment lacks dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6846a0b194dc8333a6dc72c8f162e0bd