### PR TITLE
Refactor metadata store classes

### DIFF
--- a/simgrep/indexer.py
+++ b/simgrep/indexer.py
@@ -23,7 +23,7 @@ from .exceptions import (
 )
 
 # assuming these are in .exceptions
-from .metadata_store import MetadataStore
+from .metadata_store import PersistentMetadataStore, BaseMetadataStore
 from .processor import (
     ProcessedChunkInfo,
     calculate_file_hash,
@@ -57,7 +57,7 @@ class Indexer:
         self.config = config
         self.console = console
         self.db_conn: Optional[duckdb.DuckDBPyConnection] = None
-        self.metadata_store: Optional[MetadataStore] = None
+        self.metadata_store: Optional[PersistentMetadataStore] = None
         self.usearch_index: Optional[usearch.index.Index] = None
         self._current_usearch_label: int = 0  # global counter for unique usearch labels
 
@@ -92,7 +92,7 @@ class Indexer:
         self.console.print("Preparing data stores (database and vector index)...")
         # database
         try:
-            self.metadata_store = MetadataStore(persistent=True, db_path=self.config.db_path)
+            self.metadata_store = PersistentMetadataStore(db_path=self.config.db_path)
             self.db_conn = self.metadata_store.conn
             self.console.print(f"Connected to database: {self.config.db_path}")
 

--- a/simgrep/searcher.py
+++ b/simgrep/searcher.py
@@ -7,7 +7,7 @@ from rich.console import Console
 from .config import DEFAULT_K_RESULTS, SimgrepConfig
 from .exceptions import MetadataDBError, VectorStoreError
 from .formatter import format_paths, format_show_basic
-from .metadata_store import MetadataStore
+from .metadata_store import PersistentMetadataStore
 from .models import OutputMode
 from .processor import generate_embeddings
 from .vector_store import (
@@ -18,7 +18,7 @@ from .vector_store import (
 def perform_persistent_search(
     query_text: str,
     console: Console,
-    metadata_store: MetadataStore,
+    metadata_store: PersistentMetadataStore,
     vector_index: usearch.index.Index,
     global_config: SimgrepConfig,
     output_mode: OutputMode,

--- a/tests/integration/test_indexer_persistent.py
+++ b/tests/integration/test_indexer_persistent.py
@@ -4,7 +4,7 @@ import pytest
 from rich.console import Console
 
 from simgrep.indexer import Indexer, IndexerConfig, IndexerError
-from simgrep.metadata_store import MetadataStore
+from simgrep.metadata_store import PersistentMetadataStore
 from simgrep.processor import calculate_file_hash
 from simgrep.vector_store import load_persistent_index
 
@@ -94,7 +94,7 @@ class TestIndexerPersistent:
         # Verify database content (basic checks)
         store = None
         try:
-            store = MetadataStore(persistent=True, db_path=indexer_config.db_path)
+            store = PersistentMetadataStore(db_path=indexer_config.db_path)
             db_conn = store.conn
 
             # Check indexed_files table: file1.txt, file2.md, subdir/file3.txt should be there
@@ -162,7 +162,7 @@ class TestIndexerPersistent:
 
         store = None
         try:
-            store = MetadataStore(persistent=True, db_path=indexer_config.db_path)
+            store = PersistentMetadataStore(db_path=indexer_config.db_path)
             db_conn = store.conn
             file_count_result = db_conn.execute("SELECT COUNT(*) FROM indexed_files;").fetchone()
             assert file_count_result is not None
@@ -190,7 +190,7 @@ class TestIndexerPersistent:
 
         file_to_check = sample_files_dir / "file1.txt"
 
-        store2 = MetadataStore(persistent=True, db_path=indexer_config.db_path)
+        store2 = PersistentMetadataStore(db_path=indexer_config.db_path)
         try:
             row = store2.conn.execute(
                 "SELECT content_hash, last_modified_os FROM indexed_files WHERE file_path = ?;",
@@ -230,7 +230,7 @@ class TestIndexerPersistent:
 
         store_check = None
         try:
-            store_check = MetadataStore(persistent=True, db_path=indexer_config.db_path)
+            store_check = PersistentMetadataStore(db_path=indexer_config.db_path)
             db_conn = store_check.conn
             file_count_result = db_conn.execute("SELECT COUNT(*) FROM indexed_files;").fetchone()
             assert file_count_result is not None
@@ -260,7 +260,7 @@ class TestIndexerPersistent:
 
         store_tmp = None
         try:
-            store_tmp = MetadataStore(persistent=True, db_path=indexer_config.db_path)
+            store_tmp = PersistentMetadataStore(db_path=indexer_config.db_path)
             db_conn = store_tmp.conn
             file_count_result = db_conn.execute("SELECT COUNT(*) FROM indexed_files;").fetchone()
             assert file_count_result is not None
@@ -294,7 +294,7 @@ class TestIndexerPersistent:
         file1_path = (sample_files_dir / "file1.txt").resolve()
         file2_path = (sample_files_dir / "file2.md").resolve()
 
-        store_before = MetadataStore(persistent=True, db_path=indexer_config.db_path)
+        store_before = PersistentMetadataStore(db_path=indexer_config.db_path)
         try:
             conn = store_before.conn
             file2_chunks_before_row = conn.execute(
@@ -322,7 +322,7 @@ class TestIndexerPersistent:
         indexer2 = Indexer(config=indexer_config, console=test_console)
         indexer2.index_path(target_path=sample_files_dir, wipe_existing=False)
 
-        store_after = MetadataStore(persistent=True, db_path=indexer_config.db_path)
+        store_after = PersistentMetadataStore(db_path=indexer_config.db_path)
         try:
             file2_hash_after_row = store_after.conn.execute(
                 "SELECT content_hash FROM indexed_files WHERE file_path = ?;",
@@ -357,7 +357,7 @@ class TestIndexerPersistent:
         indexer3 = Indexer(config=indexer_config, console=test_console)
         indexer3.index_path(target_path=sample_files_dir, wipe_existing=False)
 
-        store_final = MetadataStore(persistent=True, db_path=indexer_config.db_path)
+        store_final = PersistentMetadataStore(db_path=indexer_config.db_path)
         try:
             new_hash_row = store_final.conn.execute(
                 "SELECT content_hash FROM indexed_files WHERE file_path = ?;",

--- a/tests/integration/test_searcher_persistent_integration.py
+++ b/tests/integration/test_searcher_persistent_integration.py
@@ -12,7 +12,7 @@ pytest.importorskip("usearch.index")
 
 from simgrep.models import OutputMode, SimgrepConfig
 from simgrep.searcher import perform_persistent_search
-from simgrep.metadata_store import MetadataStore
+from simgrep.metadata_store import PersistentMetadataStore
 
 
 # Fixtures
@@ -60,15 +60,15 @@ def default_simgrep_config_for_search_tests(
 def populated_persistent_index_for_searcher(
     persistent_search_test_data_path: Path,
     default_simgrep_config_for_search_tests: SimgrepConfig,
-) -> Generator[
-    Tuple[MetadataStore, usearch.index.Index, SimgrepConfig], None, None
+] -> Generator[
+    Tuple[PersistentMetadataStore, usearch.index.Index, SimgrepConfig], None, None
 ]:
     """
     Indexes dummy data and provides the DB connection, USearch index, and config for tests.
     This is session-scoped for efficiency as indexing can be slow.
     """
     from simgrep.indexer import Indexer, IndexerConfig
-    from simgrep.metadata_store import MetadataStore
+    from simgrep.metadata_store import PersistentMetadataStore
     from simgrep.vector_store import load_persistent_index
 
     cfg = default_simgrep_config_for_search_tests
@@ -99,7 +99,7 @@ def populated_persistent_index_for_searcher(
 
     indexer.index_path(target_path=persistent_search_test_data_path, wipe_existing=True)
 
-    store = MetadataStore(persistent=True, db_path=db_file)
+    store = PersistentMetadataStore(db_path=db_file)
     vector_index = load_persistent_index(usearch_file)
 
     if vector_index is None:
@@ -120,7 +120,7 @@ class TestSearcherPersistentIntegration:
     def test_perform_persistent_search_show_mode_with_results(
         self,
         populated_persistent_index_for_searcher: Tuple[
-            MetadataStore, usearch.index.Index, SimgrepConfig
+            PersistentMetadataStore, usearch.index.Index, SimgrepConfig
         ],
         test_console: Console,
         capsys: pytest.CaptureFixture,
@@ -162,7 +162,7 @@ class TestSearcherPersistentIntegration:
     def test_perform_persistent_search_paths_mode_with_results(
         self,
         populated_persistent_index_for_searcher: Tuple[
-            MetadataStore, usearch.index.Index, SimgrepConfig
+            PersistentMetadataStore, usearch.index.Index, SimgrepConfig
         ],
         test_console: Console,
         capsys: pytest.CaptureFixture,
@@ -196,7 +196,7 @@ class TestSearcherPersistentIntegration:
     def test_perform_persistent_search_show_mode_no_results(
         self,
         populated_persistent_index_for_searcher: Tuple[
-            MetadataStore, usearch.index.Index, SimgrepConfig
+            PersistentMetadataStore, usearch.index.Index, SimgrepConfig
         ],
         test_console: Console,
         capsys: pytest.CaptureFixture,
@@ -225,7 +225,7 @@ class TestSearcherPersistentIntegration:
     def test_perform_persistent_search_paths_mode_no_results(
         self,
         populated_persistent_index_for_searcher: Tuple[
-            MetadataStore, usearch.index.Index, SimgrepConfig
+            PersistentMetadataStore, usearch.index.Index, SimgrepConfig
         ],
         test_console: Console,
         capsys: pytest.CaptureFixture,
@@ -254,7 +254,7 @@ class TestSearcherPersistentIntegration:
     def test_perform_persistent_search_respects_k_results(
         self,
         populated_persistent_index_for_searcher: Tuple[
-            MetadataStore,
+            PersistentMetadataStore,
             usearch.index.Index,
             SimgrepConfig,
         ],
@@ -293,7 +293,7 @@ class TestSearcherPersistentIntegration:
     def test_perform_persistent_search_paths_relative_output(
         self,
         populated_persistent_index_for_searcher: Tuple[
-            MetadataStore,
+            PersistentMetadataStore,
             usearch.index.Index,
             SimgrepConfig,
         ],


### PR DESCRIPTION
## Summary
- add BaseMetadataStore abstract class
- implement EphemeralMetadataStore and PersistentMetadataStore
- update imports and instantiations across codebase
- update unit and integration tests for new store classes

## Testing
- `make test` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6846a0b1cdb48333b2cf761fd3031e3f