### PR TITLE
Add gitignore awareness to gather_files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "usearch>=2.9.0",
     "numpy>=1.23.0",
     "duckdb>=0.10.0",
+    "pathspec>=0.12.1",
 ]
 
 [project.scripts]

--- a/tests/unit/test_gitignore.py
+++ b/tests/unit/test_gitignore.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from simgrep.utils import gather_files_to_process
+
+
+class TestGitIgnoreSupport:
+    def test_ignored_file_skipped(self, tmp_path: Path) -> None:
+        (tmp_path / ".gitignore").write_text("ignored.txt\n")
+        (tmp_path / "ignored.txt").write_text("no")
+        (tmp_path / "keep.txt").write_text("yes")
+        result = gather_files_to_process(tmp_path, ["*.txt"])
+        assert result == [(tmp_path / "keep.txt").resolve()]
+
+    def test_single_file_path_respects_gitignore(self, tmp_path: Path) -> None:
+        (tmp_path / ".gitignore").write_text("skip.txt\n")
+        file_path = tmp_path / "skip.txt"
+        file_path.write_text("x")
+        result = gather_files_to_process(file_path, ["*.txt"])
+        assert result == []


### PR DESCRIPTION
## Summary
- skip files listed in `.gitignore` when collecting files
- require `pathspec` for parsing gitignore
- test gitignore behaviour

## Testing
- `ruff check .`
- `pytest tests/unit/test_gitignore.py -q` *(fails: 2 passed)*
- ❌ `make test` *(fails to install deps)*

------
https://chatgpt.com/codex/tasks/task_e_6847579eb3988333a659f874993dbd37