### PR TITLE
Add concurrency to indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ Build the index. This may take some time for the first run.
 simgrep index
 ```
 
+### Indexing with Multiple Workers
+
+You can speed up indexing by enabling concurrent file processing. Use the
+`--workers` option to control the number of worker threads:
+
+```bash
+simgrep index --workers 4
+```
+
+By default, `simgrep` uses all available CPU cores.
+
 *Note: `simgrep` automatically detects you are in the `my-codebase` project. You can also be explicit with `--project my-codebase`.*
 
 **4. Search your project:**

--- a/simgrep/indexer.py
+++ b/simgrep/indexer.py
@@ -414,7 +414,7 @@ class Indexer:
                             stored_id, stored_hash = existing_records[resolved_fp]
                             if current_hash == stored_hash:
                                 self.console.print(
-                                    f"[yellow]Info: File {file_p} unchanged. Skipping.[/yellow]"
+                                    f"[yellow]Skipped (unchanged): {file_p}[/yellow]"
                                 )
                                 progress.update(
                                     file_processing_task,

--- a/simgrep/indexer.py
+++ b/simgrep/indexer.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional, Tuple
 
 import duckdb
@@ -46,6 +47,7 @@ class IndexerConfig(BaseModel):
     chunk_size_tokens: int
     chunk_overlap_tokens: int
     file_scan_patterns: List[str] = Field(default_factory=lambda: ["*.txt"])
+    max_index_workers: int = os.cpu_count() or 4
 
 
 class Indexer:
@@ -157,6 +159,14 @@ class Indexer:
             self.config.chunk_size_tokens,
             self.config.chunk_overlap_tokens,
         )
+
+    def _preprocess_file(self, file_path: pathlib.Path) -> Tuple[List[ProcessedChunkInfo], np.ndarray]:
+        """Extract, chunk, and embed a single file."""
+        chunks = self._extract_and_chunk_file(file_path)
+        if not chunks:
+            return [], np.empty((0, self.embedding_ndim), dtype=np.float32)
+        embeddings = self._generate_embeddings_for_chunks(chunks)
+        return chunks, embeddings
 
     def _generate_embeddings_for_chunks(self, chunks: List[ProcessedChunkInfo]) -> np.ndarray:
         """Generate embeddings for chunk texts."""
@@ -372,11 +382,41 @@ class Indexer:
             ]
             with Progress(*progress_columns, console=self.console, transient=False) as progress:
                 file_processing_task = progress.add_task("[cyan]Indexing files...", total=len(files_to_process))
-                for file_p in files_to_process:
-                    resolved_fp = file_p.resolve()
-                    if not wipe_existing and resolved_fp in existing_records:
+
+                with ThreadPoolExecutor(max_workers=self.config.max_index_workers) as pool:
+                    future_map: Dict[Any, Tuple[pathlib.Path, str, int, float]] = {}
+
+                    for file_p in files_to_process:
+                        resolved_fp = file_p.resolve()
+                        if not wipe_existing and resolved_fp in existing_records:
+                            try:
+                                current_hash = calculate_file_hash(resolved_fp)
+                            except FileNotFoundError:
+                                progress.update(
+                                    file_processing_task,
+                                    advance=1,
+                                    description=f"Skipped (missing): {file_p.name}",
+                                )
+                                total_errors += 1
+                                continue
+
+                            stored_id, stored_hash = existing_records[resolved_fp]
+                            if current_hash == stored_hash:
+                                progress.update(
+                                    file_processing_task,
+                                    advance=1,
+                                    description=f"Skipped (unchanged): {file_p.name}",
+                                )
+                                total_files_processed += 1
+                                continue
+                            assert self.metadata_store is not None
+                            removed_labels = self.metadata_store.delete_file_records(stored_id)
+                            if self.usearch_index is not None and removed_labels:
+                                self.usearch_index.remove(keys=np.array(removed_labels, dtype=np.int64))
+
                         try:
-                            current_hash = calculate_file_hash(resolved_fp)
+                            file_hash = calculate_file_hash(resolved_fp)
+                            stat = resolved_fp.stat()
                         except FileNotFoundError:
                             progress.update(
                                 file_processing_task,
@@ -386,27 +426,77 @@ class Indexer:
                             total_errors += 1
                             continue
 
-                        stored_id, stored_hash = existing_records[resolved_fp]
-                        if current_hash == stored_hash:
+                        fut = pool.submit(self._preprocess_file, resolved_fp)
+                        future_map[fut] = (
+                            resolved_fp,
+                            file_hash,
+                            stat.st_size,
+                            stat.st_mtime,
+                        )
+
+                    for fut in as_completed(future_map):
+                        file_path, fh, size_b, mtime = future_map[fut]
+                        file_display = file_path.name
+                        try:
+                            chunks, embeddings_np = fut.result()
+                        except Exception as e:
+                            self.console.print(f"[bold red]Error: Unexpected error preprocessing {file_path}: {e}[/bold red]")
+                            total_errors += 1
                             progress.update(
                                 file_processing_task,
                                 advance=1,
-                                description=f"Skipped (unchanged): {file_p.name}",
+                                description=f"Skipped (error): {file_display}",
                             )
-                            total_files_processed += 1
                             continue
-                        assert self.metadata_store is not None
-                        removed_labels = self.metadata_store.delete_file_records(stored_id)
-                        if self.usearch_index is not None and removed_labels:
-                            self.usearch_index.remove(keys=np.array(removed_labels, dtype=np.int64))
 
-                    num_c, num_e = self._process_and_index_file(resolved_fp, progress, file_processing_task)
-                    total_chunks_indexed += num_c
-                    total_errors += num_e
-                    if num_e == 0 and num_c >= 0:  # successfully processed or skipped empty/no chunks
+                        if not self.metadata_store:
+                            self.console.print(f"[bold red]Error: DB connection not available for file {file_path}. Skipping.[/bold red]")
+                            total_errors += 1
+                            progress.update(
+                                file_processing_task,
+                                advance=1,
+                                description=f"Skipped (DB error): {file_display}",
+                            )
+                            continue
+
+                        file_id = self.metadata_store.insert_indexed_file_record(
+                            file_path=str(file_path.resolve()),
+                            content_hash=fh,
+                            file_size_bytes=size_b,
+                            last_modified_os_timestamp=mtime,
+                        )
+
+                        if file_id is None:
+                            self.console.print(f"[bold red]Error: Failed to get file_id for {file_path}. Skipping.[/bold red]")
+                            total_errors += 1
+                            progress.update(
+                                file_processing_task,
+                                advance=1,
+                                description=f"Skipped (DB insert): {file_display}",
+                            )
+                            continue
+
+                        if not chunks:
+                            info_msg = "no chunks"
+                            if size_b == 0:
+                                info_msg = "empty"
+                            self.console.print(f"[yellow]Info: File {file_path} {info_msg}. Skipping chunking.[/yellow]")
+                            total_files_processed += 1
+                            progress.update(
+                                file_processing_task,
+                                advance=1,
+                                description=f"Processed ({info_msg}): {file_display}",
+                            )
+                            continue
+
+                        self._store_processed_chunks(file_id, chunks, embeddings_np)
+                        total_chunks_indexed += len(chunks)
                         total_files_processed += 1
-                    # if num_e > 0, it's an error, file not fully processed.
-                    # progress.update advances automatically in _process_and_index_file
+                        progress.update(
+                            file_processing_task,
+                            advance=1,
+                            description=f"Processed: {file_display} ({len(chunks)} chunks)",
+                        )
 
             # finalization
             if self.usearch_index is not None:

--- a/simgrep/indexer.py
+++ b/simgrep/indexer.py
@@ -399,9 +399,23 @@ class Indexer:
                                 )
                                 total_errors += 1
                                 continue
+                            except IOError as e:
+                                self.console.print(
+                                    f"[bold red]Error: I/O error processing {resolved_fp}: {e}[/bold red]"
+                                )
+                                progress.update(
+                                    file_processing_task,
+                                    advance=1,
+                                    description=f"Skipped (I/O Err): {file_p.name}",
+                                )
+                                total_errors += 1
+                                continue
 
                             stored_id, stored_hash = existing_records[resolved_fp]
                             if current_hash == stored_hash:
+                                self.console.print(
+                                    f"[yellow]Info: File {file_p} unchanged. Skipping.[/yellow]"
+                                )
                                 progress.update(
                                     file_processing_task,
                                     advance=1,
@@ -422,6 +436,17 @@ class Indexer:
                                 file_processing_task,
                                 advance=1,
                                 description=f"Skipped (missing): {file_p.name}",
+                            )
+                            total_errors += 1
+                            continue
+                        except IOError as e:
+                            self.console.print(
+                                f"[bold red]Error: I/O error processing {resolved_fp}: {e}[/bold red]"
+                            )
+                            progress.update(
+                                file_processing_task,
+                                advance=1,
+                                description=f"Skipped (I/O Err): {file_p.name}",
                             )
                             total_errors += 1
                             continue

--- a/simgrep/main.py
+++ b/simgrep/main.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import warnings
 from importlib.metadata import version
@@ -638,7 +639,7 @@ def search(
                 usearch_labels_np = np.array([cd.usearch_label for cd in all_chunkdata_objects], dtype=np.int64)
                 vector_index: usearch.index.Index = create_inmemory_index(embeddings=chunk_embeddings, labels_for_usearch=usearch_labels_np)
                 if not is_machine_readable_output:
-                    console.print(f"    Index created with {len(vector_index)} item(s). " f"Metric: {vector_index.metric}, DType: {str(vector_index.dtype)}")
+                    console.print(f"    Index created with {len(vector_index)} item(s). Metric: {vector_index.metric}, DType: {str(vector_index.dtype)}")
 
                 if not is_machine_readable_output:
                     console.print(f"  Searching index for top {top} similar chunk(s)...")
@@ -796,6 +797,12 @@ def index(
         "-p",
         help="Glob pattern(s) for files to index. Can be used multiple times. Defaults to project settings or '*.txt'.",
     ),
+    workers: Optional[int] = typer.Option(
+        None,
+        "--workers",
+        "-w",
+        help="Number of concurrent workers for indexing. Defaults to CPU count.",
+    ),
 ) -> None:
     """
     Creates or updates a persistent index for all paths in a project.
@@ -848,6 +855,7 @@ def index(
             chunk_size_tokens=global_simgrep_config.default_chunk_size_tokens,
             chunk_overlap_tokens=global_simgrep_config.default_chunk_overlap_tokens,
             file_scan_patterns=scan_patterns,
+            max_index_workers=workers if workers is not None else (os.cpu_count() or 4),
         )
 
         indexer_instance = Indexer(config=indexer_config, console=console)

--- a/tests/integration/test_indexer_workers.py
+++ b/tests/integration/test_indexer_workers.py
@@ -1,0 +1,33 @@
+import pathlib
+
+import pytest
+from rich.console import Console
+
+from simgrep.indexer import Indexer, IndexerConfig
+
+pytest.importorskip("transformers")
+pytest.importorskip("sentence_transformers")
+pytest.importorskip("usearch.index")
+
+
+def test_index_with_workers(tmp_path: pathlib.Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "a.txt").write_text("hello world")
+    (data_dir / "b.txt").write_text("another file")
+
+    cfg = IndexerConfig(
+        project_name="workers_proj",
+        db_path=tmp_path / "meta.duckdb",
+        usearch_index_path=tmp_path / "index.usearch",
+        embedding_model_name="sentence-transformers/all-MiniLM-L6-v2",
+        chunk_size_tokens=16,
+        chunk_overlap_tokens=0,
+        file_scan_patterns=["*.txt"],
+        max_index_workers=2,
+    )
+    indexer = Indexer(cfg, Console(quiet=True))
+    indexer.run_index([data_dir], wipe_existing=True)
+
+    assert cfg.db_path.exists()
+    assert cfg.usearch_index_path.exists()


### PR DESCRIPTION
## Summary
- support `max_index_workers` in Indexer
- index files concurrently with ThreadPoolExecutor
- expose `--workers` option in CLI
- document concurrent indexing
- test basic multi-worker indexing

## Testing
- `ruff check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6848633c4c008333bb843e15940fca40