### PR TITLE
Add --yes option for index command

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -308,7 +308,7 @@ The tool is designed to be intuitive for simple use cases ("semantic grep replac
 *   **Progress:** `Rich` progress bars for indexing and other long operations.
 *   **Status Messages:** Clear, concise messages for success, warnings, errors.
 *   **`simgrep status [--project <name>]`:** Shows indexed paths, number of files/chunks, DB size, embedding model, last index time for the project.
-*   **Confirmation:** Prompts for destructive actions (e.g., `index --rebuild`, `project delete`).
+*   **Confirmation:** Prompts for destructive actions (e.g., `index --rebuild`, `project delete`). Use `--yes` to skip prompts in automation.
 *   **Error Reporting:** User-friendly error messages with suggestions if possible. Stack traces hidden by default, shown with `--verbose`.
 
 **7.3. Defaults and Tunability**

--- a/simgrep/main.py
+++ b/simgrep/main.py
@@ -400,6 +400,11 @@ def index(
         "-w",
         help="Number of concurrent workers for indexing. Defaults to CPU count.",
     ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        help="Skip confirmation prompts and assume 'yes'.",
+    ),
 ) -> None:
     """
     Creates or updates a persistent index for all paths in a project.
@@ -415,12 +420,13 @@ def index(
     console.print(f"Starting indexing for project '[magenta]{active_project}[/magenta]'")
     if rebuild:
         console.print(f"[bold yellow]Warning: This will wipe and rebuild the '{active_project}' project index.[/bold yellow]")
-        if not typer.confirm(
-            f"Are you sure you want to wipe and rebuild the '{active_project}' project index?",
-            default=False,
-        ):
-            console.print("Aborted indexing.")
-            raise typer.Abort()
+        if not yes:
+            if not typer.confirm(
+                f"Are you sure you want to wipe and rebuild the '{active_project}' project index?",
+                default=False,
+            ):
+                console.print("Aborted indexing.")
+                raise typer.Abort()
 
     try:
         global_db_path = global_simgrep_config.db_directory / "global_metadata.duckdb"

--- a/tests/e2e/test_cli_persistent_e2e.py
+++ b/tests/e2e/test_cli_persistent_e2e.py
@@ -138,8 +138,7 @@ def populated_persistent_index_func_scope(temp_simgrep_home: pathlib.Path, sampl
 
     # 2. Index the sample documents
     index_result = run_simgrep_command(
-        ["index", "--project", "default", "--rebuild"],
-        input_str="y\n",
+        ["index", "--project", "default", "--rebuild", "--yes"],
     )
     assert index_result.exit_code == 0
 
@@ -158,8 +157,7 @@ def populated_persistent_index(temp_simgrep_home: pathlib.Path, sample_docs_dir_
 
     # 2. Index the sample documents
     index_result = run_simgrep_command(
-        ["index", "--project", "default", "--rebuild"],
-        input_str="y\n",
+        ["index", "--project", "default", "--rebuild", "--yes"],
     )
     assert index_result.exit_code == 0
     assert "Successfully indexed" in index_result.stdout
@@ -258,7 +256,7 @@ class TestCliPersistentE2E:
 
         run_simgrep_command(["init", "--global"])
         run_simgrep_command(["project", "add-path", str(empty_dir)])
-        index_result = run_simgrep_command(["index", "--rebuild"], input_str="y\n")
+        index_result = run_simgrep_command(["index", "--rebuild", "--yes"])
         assert index_result.exit_code == 0
         assert "No files found to index" in index_result.stdout
         assert "0 files processed" in index_result.stdout  # Or similar message indicating no work done
@@ -407,7 +405,7 @@ class TestCliPersistentE2E:
         assert add_src_again_result.exit_code == 0
 
         # Index the project
-        index_result = run_simgrep_command(["index", "--project", "multi-path-proj", "--rebuild"], input_str="y\n")
+        index_result = run_simgrep_command(["index", "--project", "multi-path-proj", "--rebuild", "--yes"])
         assert index_result.exit_code == 0
         assert "2 files processed" in index_result.stdout  # doc1.txt and util.txt
 
@@ -503,9 +501,8 @@ class TestCliPersistentE2E:
         # 3. Add path and index from root
         run_simgrep_command(["project", "add-path", str(project_root)], cwd=project_root)
         index_result = run_simgrep_command(
-            ["index", "--rebuild", "--pattern", "*.md"],
+            ["index", "--rebuild", "--pattern", "*.md", "--yes"],
             cwd=project_root,
-            input_str="y\n",
         )
         assert index_result.exit_code == 0, index_result.stdout
 
@@ -539,7 +536,7 @@ class TestCliPersistentE2E:
         assert f'project_name = "{expected_project_name}"' in simgrep_config.read_text()
 
         # 4. Verify indexing works
-        index_result = run_simgrep_command(["index", "--rebuild"], cwd=project_dir, input_str="y\n")
+        index_result = run_simgrep_command(["index", "--rebuild", "--yes"], cwd=project_dir)
         assert index_result.exit_code == 0, index_result.stdout
         assert f"Successfully indexed project '{expected_project_name}'" in index_result.stdout
 
@@ -590,8 +587,8 @@ def populated_filtering_index(temp_simgrep_home: pathlib.Path, sample_docs_for_f
             "*.txt",
             "--pattern",
             "*.py",
+            "--yes",
         ],
-        input_str="y\n",
     )
     assert index_result.exit_code == 0
     assert "Successfully indexed" in index_result.stdout
@@ -663,7 +660,7 @@ class TestCliIndexerRobustnessE2E:
         run_simgrep_command(["init", "--global"])
         run_simgrep_command(["project", "create", "symlink-test"])
         run_simgrep_command(["project", "add-path", str(project_dir), "--project", "symlink-test"])
-        run_simgrep_command(["index", "--project", "symlink-test", "--rebuild"], input_str="y\n")
+        run_simgrep_command(["index", "--project", "symlink-test", "--rebuild", "--yes"])
 
         search_result = run_simgrep_command(["search", "symlinked file", "--project", "symlink-test"])
         assert search_result.exit_code == 0
@@ -685,7 +682,7 @@ class TestCliIndexerRobustnessE2E:
         run_simgrep_command(["init", "--global"])
         run_simgrep_command(["project", "create", "symlink-dir-test"])
         run_simgrep_command(["project", "add-path", str(project_dir), "--project", "symlink-dir-test"])
-        index_result = run_simgrep_command(["index", "--project", "symlink-dir-test", "--rebuild"], input_str="y\n")
+        index_result = run_simgrep_command(["index", "--project", "symlink-dir-test", "--rebuild", "--yes"])
         assert index_result.exit_code == 0
 
         search_result = run_simgrep_command(["search", "symlinked directory", "--project", "symlink-dir-test"])
@@ -708,7 +705,7 @@ class TestCliIndexerRobustnessE2E:
             run_simgrep_command(["init", "--global"])
             run_simgrep_command(["project", "create", "unreadable-test"])
             run_simgrep_command(["project", "add-path", str(project_dir), "--project", "unreadable-test"])
-            index_result = run_simgrep_command(["index", "--project", "unreadable-test", "--rebuild"], input_str="y\n")
+            index_result = run_simgrep_command(["index", "--project", "unreadable-test", "--rebuild", "--yes"])
 
             assert index_result.exit_code == 0
             assert "Error: I/O error processing" in index_result.stdout
@@ -733,7 +730,7 @@ class TestCliIndexerRobustnessE2E:
         run_simgrep_command(["init", "--global"])
         run_simgrep_command(["project", "create", "binary-test"])
         run_simgrep_command(["project", "add-path", str(project_dir), "--project", "binary-test"])
-        index_result = run_simgrep_command(["index", "--project", "binary-test", "--rebuild", "--pattern", "*.*"], input_str="y\n")
+        index_result = run_simgrep_command(["index", "--project", "binary-test", "--rebuild", "--pattern", "*.*", "--yes"])
 
         assert index_result.exit_code == 0
         assert "1 files processed" in index_result.stdout

--- a/tests/e2e/test_project_workflow.py
+++ b/tests/e2e/test_project_workflow.py
@@ -51,7 +51,7 @@ def test_project_init_index_and_search_workflow(tmp_path: Path) -> None:
             assert (project_dir / ".simgrep").exists()
 
             # 3. Index the project (explicitly, to avoid cwd flakiness)
-            index_result = runner.invoke(app, ["index", "--rebuild", "--project", "my-test-project"], input="y\n")
+            index_result = runner.invoke(app, ["index", "--rebuild", "--project", "my-test-project", "--yes"])
             assert index_result.exit_code == 0, index_result.stdout
             assert "Successfully indexed project 'my-test-project'" in index_result.stdout
 


### PR DESCRIPTION
## Summary
- add `--yes` to `index` command for skipping confirmation
- document automation flag in architecture doc
- update tests to use `--yes`

## Testing
- `ruff check simgrep/main.py tests/e2e/test_cli_persistent_e2e.py tests/e2e/test_project_workflow.py`
- `mypy simgrep/main.py tests/e2e/test_cli_persistent_e2e.py tests/e2e/test_project_workflow.py` *(fails: Cannot find module 'pydantic')*
- `pytest tests/e2e/test_cli_persistent_e2e.py -k index_prompt_decline_prevents_reindexing -q` *(fails: ModuleNotFoundError: No module named 'duckdb')*

------
https://chatgpt.com/codex/tasks/task_e_6848995117208333be78450994b3def5