### PR TITLE
Use dataclasses for chunks

### DIFF
--- a/simgrep/ephemeral_searcher.py
+++ b/simgrep/ephemeral_searcher.py
@@ -20,7 +20,7 @@ extract_text_from_file: Optional[Any] = None
 generate_embeddings: Optional[Any] = None
 load_embedding_model: Optional[Any] = None
 load_tokenizer: Optional[Any] = None
-ProcessedChunkInfo: Optional[Any] = None
+ProcessedChunkInfo: Optional[Any] = None  # alias for the dataclass, loaded lazily
 
 
 class EphemeralSearcher:
@@ -56,7 +56,7 @@ class EphemeralSearcher:
             )
         ):
             from .processor import (
-                ProcessedChunkInfo as _ProcessedChunkInfo,
+                ProcessedChunk as _ProcessedChunkInfo,
             )
             from .processor import (
                 chunk_text_by_tokens as _chunk_text_by_tokens,
@@ -159,13 +159,13 @@ class EphemeralSearcher:
                         for c in chunk_infos:
                             all_chunks.append(
                                 ChunkData(
-                                    text=c["text"],
+                                    text=c.text,
                                     source_file_path=file_path,
                                     source_file_id=file_idx,
                                     usearch_label=label_counter,
-                                    start_char_offset=c["start_char_offset"],
-                                    end_char_offset=c["end_char_offset"],
-                                    token_count=c["token_count"],
+                                    start_char_offset=c.start_char_offset,
+                                    end_char_offset=c.end_char_offset,
+                                    token_count=c.token_count,
                                 )
                             )
                             label_counter += 1

--- a/simgrep/metadata_db.py
+++ b/simgrep/metadata_db.py
@@ -1,19 +1,18 @@
-import datetime
 import logging
 import pathlib
-from typing import Any, Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import duckdb
 
 # assuming models.py is in the same directory or simgrep is installed
 try:
     from .exceptions import MetadataDBError
-    from .models import ChunkData, ProjectConfig, SimgrepConfig
+    from .models import ProjectConfig, SimgrepConfig
 except ImportError:
     # this fallback might be needed if running scripts directly from the simgrep folder
     # or if the package structure is not fully resolved in some contexts.
     from simgrep.exceptions import MetadataDBError  # type: ignore
-    from simgrep.models import ChunkData, ProjectConfig, SimgrepConfig  # type: ignore
+    from simgrep.models import ProjectConfig, SimgrepConfig  # type: ignore
 
 logger = logging.getLogger(__name__)
 

--- a/simgrep/processor.py
+++ b/simgrep/processor.py
@@ -1,7 +1,8 @@
 import hashlib
+from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, List, Optional, TypedDict, cast
+from typing import Any, Dict, List, Optional, cast
 
 import numpy as np
 import unstructured.partition.auto as auto_partition
@@ -13,7 +14,8 @@ from transformers import AutoTokenizer, PreTrainedTokenizerBase
 from unstructured.documents.elements import Element
 
 
-class ProcessedChunkInfo(TypedDict):
+@dataclass
+class ProcessedChunk:
     text: str
     start_char_offset: int
     end_char_offset: int
@@ -108,7 +110,7 @@ def chunk_text_by_tokens(
     tokenizer: PreTrainedTokenizerBase,
     chunk_size_tokens: int,
     overlap_tokens: int,
-) -> List[ProcessedChunkInfo]:
+) -> List[ProcessedChunk]:
     """
     Splits a given text into a list of overlapping token-based chunks.
     """
@@ -135,7 +137,7 @@ def chunk_text_by_tokens(
     if not all_token_ids:
         return []
 
-    chunks: List[ProcessedChunkInfo] = []
+    chunks: List[ProcessedChunk] = []
     step = chunk_size_tokens - overlap_tokens
 
     current_token_idx = 0
@@ -159,7 +161,7 @@ def chunk_text_by_tokens(
         num_tokens_in_this_chunk = len(chunk_token_ids_batch)
 
         chunks.append(
-            ProcessedChunkInfo(
+            ProcessedChunk(
                 text=chunk_text,
                 start_char_offset=start_char,
                 end_char_offset=end_char,

--- a/tests/property/test_chunker.py
+++ b/tests/property/test_chunker.py
@@ -51,8 +51,8 @@ def test_chunk_text_roundtrip(tokenizer: PreTrainedTokenizerBase, text: str, chu
     assert len(chunks) == 1
     chunk = chunks[0]
 
-    assert chunk["text"] == expected_decoded_text
+    assert chunk.text == expected_decoded_text
 
-    assert chunk["start_char_offset"] == all_offsets[0][0]
-    assert chunk["end_char_offset"] == all_offsets[-1][1]
-    assert chunk["start_char_offset"] <= chunk["end_char_offset"]
+    assert chunk.start_char_offset == all_offsets[0][0]
+    assert chunk.end_char_offset == all_offsets[-1][1]
+    assert chunk.start_char_offset <= chunk.end_char_offset

--- a/tests/unit/test_ephemeral_searcher.py
+++ b/tests/unit/test_ephemeral_searcher.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import Any, Dict, List
+from typing import Any, List
 
 import numpy as np
 import pytest
@@ -7,6 +7,7 @@ from rich.console import Console
 
 from simgrep.ephemeral_searcher import EphemeralSearcher
 from simgrep.models import OutputMode, SearchResult
+from simgrep.processor import ProcessedChunk
 
 
 class DummyTokenizer:
@@ -25,14 +26,15 @@ def fake_extract_text_from_file(path: pathlib.Path) -> str:
     return "dummy text for testing"
 
 
-def fake_chunk_text_by_tokens(**kwargs: Any) -> List[Dict[str, Any]]:
+
+def fake_chunk_text_by_tokens(**kwargs: Any) -> List[ProcessedChunk]:
     return [
-        {
-            "text": "chunk text",
-            "start_char_offset": 0,
-            "end_char_offset": 5,
-            "token_count": 1,
-        }
+        ProcessedChunk(
+            text="chunk text",
+            start_char_offset=0,
+            end_char_offset=5,
+            token_count=1,
+        )
     ]
 
 

--- a/tests/unit/test_indexer_methods.py
+++ b/tests/unit/test_indexer_methods.py
@@ -4,7 +4,7 @@ import pytest
 from rich.console import Console
 
 from simgrep.indexer import Indexer, IndexerConfig
-from simgrep.processor import ProcessedChunkInfo
+from simgrep.processor import ProcessedChunk
 
 pytest.importorskip("transformers")
 pytest.importorskip("sentence_transformers")
@@ -34,11 +34,11 @@ def test_extract_and_chunk_file(tmp_path: pathlib.Path, indexer_instance: Indexe
     file_path.write_text("Hello world. This is a test file.")
     chunks = indexer_instance._extract_and_chunk_file(file_path)
     assert len(chunks) > 0
-    assert "text" in chunks[0]
+    assert hasattr(chunks[0], "text")
 
 
 def test_generate_embeddings_for_chunks(indexer_instance: Indexer) -> None:
-    chunks = [ProcessedChunkInfo(text="hello", start_char_offset=0, end_char_offset=5, token_count=1)]
+    chunks = [ProcessedChunk(text="hello", start_char_offset=0, end_char_offset=5, token_count=1)]
     embeddings = indexer_instance._generate_embeddings_for_chunks(chunks)
     assert embeddings.shape[0] == len(chunks)
     assert embeddings.shape[1] == indexer_instance.embedding_ndim
@@ -55,7 +55,7 @@ def test_store_processed_chunks(tmp_path: pathlib.Path, indexer_instance: Indexe
     )
     assert file_id is not None
 
-    chunks = [ProcessedChunkInfo(text="hello", start_char_offset=0, end_char_offset=5, token_count=1)]
+    chunks = [ProcessedChunk(text="hello", start_char_offset=0, end_char_offset=5, token_count=1)]
     embeddings = indexer_instance._generate_embeddings_for_chunks(chunks)
     indexer_instance._store_processed_chunks(file_id, chunks, embeddings)
 

--- a/tests/unit/test_processor.py
+++ b/tests/unit/test_processor.py
@@ -204,10 +204,10 @@ class TestChunkTextByTokens:
         chunks = chunk_text_by_tokens(text, tokenizer, 10, 2)
         assert len(chunks) == 1
         # all-minilm-l6-v2 is uncased, so output text will be lowercased.
-        assert chunks[0]["text"] == text.strip().lower()
-        assert chunks[0]["start_char_offset"] == 0
-        assert chunks[0]["end_char_offset"] == len(text)
-        assert chunks[0]["token_count"] == len(tokenizer.encode(text, add_special_tokens=False))
+        assert chunks[0].text == text.strip().lower()
+        assert chunks[0].start_char_offset == 0
+        assert chunks[0].end_char_offset == len(text)
+        assert chunks[0].token_count == len(tokenizer.encode(text, add_special_tokens=False))
 
     def test_text_equals_chunk_size(self, tokenizer: PreTrainedTokenizerBase) -> None:
         from simgrep.processor import chunk_text_by_tokens
@@ -226,8 +226,8 @@ class TestChunkTextByTokens:
         chunks = chunk_text_by_tokens(text, tokenizer, len(actual_token_ids), 0)
         assert len(chunks) == 1
         # all-minilm-l6-v2 is uncased, so output text will be lowercased.
-        assert chunks[0]["text"].strip() == text.strip().lower()
-        assert chunks[0]["token_count"] == len(actual_token_ids)
+        assert chunks[0].text.strip() == text.strip().lower()
+        assert chunks[0].token_count == len(actual_token_ids)
 
     def test_multiple_chunks_no_overlap(self, tokenizer: PreTrainedTokenizerBase) -> None:
         from simgrep.processor import chunk_text_by_tokens
@@ -246,16 +246,16 @@ class TestChunkTextByTokens:
 
         reconstructed_token_ids = []
         for chunk in chunks:
-            chunk_token_ids = tokenizer.encode(chunk["text"], add_special_tokens=False)
+            chunk_token_ids = tokenizer.encode(chunk.text, add_special_tokens=False)
             reconstructed_token_ids.extend(chunk_token_ids)
 
         # we can't directly compare token_ids list due to how chunking might split words/subwords
         # but we can check character offsets
-        assert chunks[0]["start_char_offset"] == 0
+        assert chunks[0].start_char_offset == 0
         if len(chunks) > 1:
             # the start of the second chunk should be the end of the first token sequence of the first chunk
             # this is also tricky. let's check total length.
-            assert chunks[-1]["end_char_offset"] == len(text)
+            assert chunks[-1].end_char_offset == len(text)
 
     def test_multiple_chunks_with_overlap(self, tokenizer: PreTrainedTokenizerBase) -> None:
         from simgrep.processor import chunk_text_by_tokens
@@ -272,7 +272,7 @@ class TestChunkTextByTokens:
             # the first `overlap` tokens of the second chunk's *token source*.
             # this is hard to verify perfectly without knowing the exact token boundaries from original.
             # a simpler check: the start_char_offset of chunk2 should be less than end_char_offset of chunk1
-            assert chunks[1]["start_char_offset"] < chunks[0]["end_char_offset"]
+            assert chunks[1].start_char_offset < chunks[0].end_char_offset
 
     def test_invalid_chunk_size(self, tokenizer: PreTrainedTokenizerBase) -> None:
         from simgrep.processor import chunk_text_by_tokens
@@ -318,10 +318,10 @@ class TestChunkTextByTokens:
         # Expected text: "word1 word2"
         # Expected offsets from original text: tokens span from char 0 to char 14
         chunk1 = chunks[0]
-        assert chunk1["text"] == "word1 word2"
-        assert chunk1["start_char_offset"] == 0
-        assert chunk1["end_char_offset"] == 14
-        assert chunk1["token_count"] == 4
+        assert chunk1.text == "word1 word2"
+        assert chunk1.start_char_offset == 0
+        assert chunk1.end_char_offset == 14
+        assert chunk1.token_count == 4
 
         # --- Check Chunk 2 ---
         # Step is chunk_size - overlap = 3. Next chunk starts at token index 3.
@@ -329,20 +329,20 @@ class TestChunkTextByTokens:
         # Expected text: "##2 word3 word"
         # Expected offsets from original text: tokens span from char 13 to char 28
         chunk2 = chunks[1]
-        assert chunk2["text"] == "##2 word3 word"
-        assert chunk2["start_char_offset"] == 13
-        assert chunk2["end_char_offset"] == 28
-        assert chunk2["token_count"] == 4
+        assert chunk2.text == "##2 word3 word"
+        assert chunk2.start_char_offset == 13
+        assert chunk2.end_char_offset == 28
+        assert chunk2.token_count == 4
 
         # --- Check Chunk 3 ---
         # Step is 3. Next chunk starts at token index 6.
         # Expected tokens: ['word', '##4'] (indices 6-7)
         # Expected text: "word4"
         chunk3 = chunks[2]
-        assert chunk3["text"] == "word4"
-        assert chunk3["start_char_offset"] == 24
-        assert chunk3["end_char_offset"] == 29
-        assert chunk3["token_count"] == 2
+        assert chunk3.text == "word4"
+        assert chunk3.start_char_offset == 24
+        assert chunk3.end_char_offset == 29
+        assert chunk3.token_count == 2
 
 
 class TestGenerateEmbeddings:


### PR DESCRIPTION
## Summary
- replace `ProcessedChunkInfo` TypedDict with `ProcessedChunk` dataclass
- update indexer and ephemeral searcher to use dataclass fields
- adapt metadata DB imports
- adjust unit and property tests for dataclass
- run ruff to keep formatting clean

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_68489e38f7e883339447d0b2f8a72f95