### PR TITLE
Add project manager

### DIFF
--- a/simgrep/project_manager.py
+++ b/simgrep/project_manager.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+from typing import List, Optional
+
+from .config import SimgrepConfig, load_global_config
+from .metadata_db import (
+    MetadataDBError,
+    add_project_path,
+    connect_global_db,
+    create_project_scaffolding,
+    get_all_projects,
+    get_project_by_name,
+    get_project_config,
+)
+from .models import ProjectConfig
+
+
+class ProjectManager:
+    """High level helper for managing simgrep projects."""
+
+    def __init__(self, config: Optional[SimgrepConfig] = None) -> None:
+        self.config = config or load_global_config()
+        self._db_path = self.config.db_directory / "global_metadata.duckdb"
+
+    def _connect(self):
+        return connect_global_db(self._db_path)
+
+    def create_project(self, name: str) -> ProjectConfig:
+        """Create a new project and return its configuration."""
+        conn = self._connect()
+        try:
+            if get_project_by_name(conn, name) is not None:
+                raise MetadataDBError(f"Project '{name}' already exists.")
+            return create_project_scaffolding(conn, self.config, name)
+        finally:
+            conn.close()
+
+    def add_path(self, project_name: str, path: Path | str) -> None:
+        """Associate a path with the given project."""
+        conn = self._connect()
+        try:
+            proj = get_project_by_name(conn, project_name)
+            if proj is None:
+                raise MetadataDBError(f"Project '{project_name}' not found.")
+            project_id = int(proj[0])
+            add_project_path(conn, project_id, str(path))
+        finally:
+            conn.close()
+
+    def get_config(self, project_name: str) -> Optional[ProjectConfig]:
+        """Return the ``ProjectConfig`` for ``project_name`` if it exists."""
+        conn = self._connect()
+        try:
+            return get_project_config(conn, project_name)
+        finally:
+            conn.close()
+
+    def list_projects(self) -> List[str]:
+        """Return the list of known project names."""
+        conn = self._connect()
+        try:
+            return get_all_projects(conn)
+        finally:
+            conn.close()

--- a/tests/e2e/test_cli_persistent_e2e.py
+++ b/tests/e2e/test_cli_persistent_e2e.py
@@ -627,8 +627,9 @@ class TestCliConfigE2E:
         # Run a command that requires global config
         result = run_simgrep_command(["project", "list"])
         assert result.exit_code == 1
-        assert "Global config not found" in result.stdout
-        assert "Please run 'simgrep init --global'" in result.stdout
+        cleaned_stdout = " ".join(result.stdout.split())
+        assert "Global config not found" in cleaned_stdout
+        assert "Please run 'simgrep init --global' to create it." in cleaned_stdout
 
     def test_status_on_fresh_init(self, temp_simgrep_home: pathlib.Path) -> None:
         """Tests the status command on a fresh global init."""

--- a/tests/unit/test_project_manager.py
+++ b/tests/unit/test_project_manager.py
@@ -1,0 +1,42 @@
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from simgrep.config import initialize_global_config, load_global_config
+from simgrep.project_manager import ProjectManager
+
+
+def _mock_expand(base: Path):
+    def _inner(path: str) -> str:
+        if path == "~" or path.startswith("~/"):
+            return path.replace("~", str(base), 1)
+        return os.path.expanduser(path)
+
+    return _inner
+
+
+def test_create_add_get(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+
+    with patch("os.path.expanduser", side_effect=_mock_expand(home)):
+        initialize_global_config()
+        cfg = load_global_config()
+        manager = ProjectManager(cfg)
+
+        project_cfg = manager.create_project("myproj")
+        project_dir = cfg.db_directory / "projects" / "myproj"
+        assert project_dir.exists()
+        assert project_cfg.db_path == project_dir / "metadata.duckdb"
+
+        sample_path = tmp_path / "data"
+        sample_path.mkdir()
+        manager.add_path("myproj", sample_path)
+
+        proj_cfg_after = manager.get_config("myproj")
+        assert proj_cfg_after is not None
+        assert sample_path.resolve() in proj_cfg_after.indexed_paths
+
+        projects = manager.list_projects()
+        assert "myproj" in projects
+        assert "default" in projects


### PR DESCRIPTION
## Summary
- introduce `ProjectManager` for high level project management
- refactor CLI project commands to use the new helper
- cover project creation and path management with unit tests

## Testing
- `ruff check simgrep/main.py simgrep/project_manager.py tests/unit/test_project_manager.py`
- `pytest -q tests/unit/test_project_manager.py`
- `mypy simgrep/project_manager.py simgrep/main.py tests/unit/test_project_manager.py` *(fails: missing imports)*

------
https://chatgpt.com/codex/tasks/task_e_6848a1ebfb148333bd67cf958f324056