### PR TITLE
Add ephemeral search caching

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -232,14 +232,12 @@ The tool is designed to be intuitive for simple use cases ("semantic grep replac
 *   **Implicit/Ephemeral Indexing (Grep-like usage):**
     *   `simgrep "query" ./some/path`
     1.  No project context is active for `./some/path`.
-    2.  An ephemeral, in-memory DuckDB and USearch index are created.
-    3.  `./some/path` is recursively scanned (if dir) or read (if file).
-    4.  Files are processed, chunked, embedded, and added to the ephemeral index.
-    5.  Search is performed against this temporary index.
+    2.  A cache directory is determined under `~/.config/simgrep/ephemeral_cache/<hash>`.
+    3.  If the cache files exist, the metadata DB and USearch index are loaded from disk.
+    4.  Otherwise the target path is indexed with those paths and saved for reuse.
+    5.  Search is performed against this persistent cache.
     6.  Results are displayed.
-    7.  Ephemeral index is discarded.
-    *   This provides immediate utility without persistent state for one-off searches.
-    *   A warning might suggest creating a project for faster subsequent searches on the same path.
+    *   This still works for one-off searches, but repeated searches of the same path are faster thanks to the on-disk cache.
 
 **6.2. Indexing**
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -4,7 +4,8 @@
 
 ## Ephemeral Search
 
-For one-off queries, `simgrep` creates a temporary index in memory, searches it, then discards it.
+For ad-hoc queries, `simgrep` builds an index in `~/.config/simgrep/ephemeral_cache/<hash>`.
+If that cache already exists it is reused for faster results.
 
 ```mermaid
 sequenceDiagram
@@ -14,8 +15,8 @@ sequenceDiagram
     participant USearch
     participant DuckDB
     User->>simgrep: simgrep search "query" path
-    simgrep->>DuckDB: store chunks in memory
-    simgrep->>USearch: build in-memory index
+    simgrep->>DuckDB: store chunks in cache
+    simgrep->>USearch: build or load cached index
     simgrep->>USearch: query embeddings
     USearch-->>simgrep: similar chunks
     simgrep->>User: display results

--- a/simgrep/config.py
+++ b/simgrep/config.py
@@ -53,6 +53,7 @@ def initialize_global_config(overwrite: bool = False) -> None:
     try:
         config.db_directory.mkdir(parents=True, exist_ok=True)
         config.default_project_data_dir.mkdir(parents=True, exist_ok=True)
+        config.ephemeral_cache_dir.mkdir(parents=True, exist_ok=True)
     except OSError as e:
         error_message = f"Fatal: Could not create simgrep data directory at '{config.db_directory}'. Please check permissions. Error: {e}"
         print(error_message, file=sys.stderr)

--- a/simgrep/ephemeral_searcher.py
+++ b/simgrep/ephemeral_searcher.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 from pathlib import Path
 from typing import List, Optional
 
@@ -36,6 +37,7 @@ class EphemeralSearcher:
     ) -> None:
         cfg = self.config
         search_patterns = list(patterns) if patterns else ["*.txt"]
+        is_machine = output_mode in (OutputMode.json, OutputMode.paths)
 
         db_path, index_path = get_ephemeral_cache_paths(path_to_search, cfg)
         store: Optional[MetadataStore] = None
@@ -56,7 +58,8 @@ class EphemeralSearcher:
                 chunk_overlap_tokens=cfg.default_chunk_overlap_tokens,
                 file_scan_patterns=search_patterns,
             )
-            indexer = Indexer(config=idx_cfg, console=self.console)
+            index_console = self.console if not is_machine else Console(file=io.StringIO())
+            indexer = Indexer(config=idx_cfg, console=index_console)
             indexer.run_index([path_to_search], wipe_existing=True)
             store = MetadataStore(persistent=True, db_path=db_path)
             index = load_persistent_index(index_path)

--- a/simgrep/ephemeral_searcher.py
+++ b/simgrep/ephemeral_searcher.py
@@ -1,30 +1,21 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
-import numpy as np
-import typer
 from rich.console import Console
-from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn
 
 from .config import DEFAULT_K_RESULTS, SimgrepConfig
-from .formatter import format_count, format_json, format_paths, format_show_basic
+from .indexer import Indexer, IndexerConfig
 from .metadata_store import MetadataStore
-from .models import ChunkData, OutputMode, SearchResult
-from .utils import gather_files_to_process
-from .vector_store import create_inmemory_index, search_inmemory_index
-
-chunk_text_by_tokens: Optional[Any] = None
-extract_text_from_file: Optional[Any] = None
-generate_embeddings: Optional[Any] = None
-load_embedding_model: Optional[Any] = None
-load_tokenizer: Optional[Any] = None
-ProcessedChunkInfo: Optional[Any] = None  # alias for the dataclass, loaded lazily
+from .models import OutputMode
+from .searcher import perform_persistent_search
+from .utils import get_ephemeral_cache_paths
+from .vector_store import load_persistent_index
 
 
 class EphemeralSearcher:
-    """Utility to perform one-off searches on arbitrary files or directories."""
+    """Perform ad-hoc searches with a cached on-disk index."""
 
     def __init__(self, console: Optional[Console] = None, config: Optional[SimgrepConfig] = None) -> None:
         self.console = console or Console()
@@ -43,256 +34,51 @@ class EphemeralSearcher:
         file_filter: Optional[List[str]] = None,
         keyword_filter: Optional[str] = None,
     ) -> None:
-        """Run an ephemeral search and print results to the console."""
-        global chunk_text_by_tokens, extract_text_from_file, generate_embeddings, load_embedding_model, load_tokenizer, ProcessedChunkInfo
-        if any(
-            f is None
-            for f in (
-                chunk_text_by_tokens,
-                extract_text_from_file,
-                generate_embeddings,
-                load_embedding_model,
-                load_tokenizer,
-            )
-        ):
-            from .processor import (
-                ProcessedChunk as _ProcessedChunkInfo,
-            )
-            from .processor import (
-                chunk_text_by_tokens as _chunk_text_by_tokens,
-            )
-            from .processor import (
-                extract_text_from_file as _extract_text_from_file,
-            )
-            from .processor import (
-                generate_embeddings as _generate_embeddings,
-            )
-            from .processor import (
-                load_embedding_model as _load_embedding_model,
-            )
-            from .processor import (
-                load_tokenizer as _load_tokenizer,
-            )
-
-            if chunk_text_by_tokens is None:
-                chunk_text_by_tokens = _chunk_text_by_tokens
-            if extract_text_from_file is None:
-                extract_text_from_file = _extract_text_from_file
-            if generate_embeddings is None:
-                generate_embeddings = _generate_embeddings
-            if load_embedding_model is None:
-                load_embedding_model = _load_embedding_model
-            if load_tokenizer is None:
-                load_tokenizer = _load_tokenizer
-            if ProcessedChunkInfo is None:
-                ProcessedChunkInfo = _ProcessedChunkInfo
-
-
-        is_machine = output_mode in (OutputMode.json, OutputMode.paths)
         cfg = self.config
+        search_patterns = list(patterns) if patterns else ["*.txt"]
 
-        if not is_machine:
-            self.console.print(f"Performing ephemeral search for: '[bold blue]{query_text}[/bold blue]' in path: '[green]{path_to_search}[/green]'")
-
+        db_path, index_path = get_ephemeral_cache_paths(path_to_search, cfg)
         store: Optional[MetadataStore] = None
+        index = None
+
+        if db_path.exists() and index_path.exists():
+            store = MetadataStore(persistent=True, db_path=db_path)
+            index = load_persistent_index(index_path)
+
+        if store is None or index is None:
+            db_path.parent.mkdir(parents=True, exist_ok=True)
+            idx_cfg = IndexerConfig(
+                project_name="ephemeral",
+                db_path=db_path,
+                usearch_index_path=index_path,
+                embedding_model_name=cfg.default_embedding_model_name,
+                chunk_size_tokens=cfg.default_chunk_size_tokens,
+                chunk_overlap_tokens=cfg.default_chunk_overlap_tokens,
+                file_scan_patterns=search_patterns,
+            )
+            indexer = Indexer(config=idx_cfg, console=self.console)
+            indexer.run_index([path_to_search], wipe_existing=True)
+            store = MetadataStore(persistent=True, db_path=db_path)
+            index = load_persistent_index(index_path)
+
+        if store is None or index is None:
+            self.console.print(f"[bold red]Failed to prepare ephemeral index at {index_path}")
+            return
+
         try:
-            if not is_machine:
-                self.console.print("\n[bold]Setup: Initializing In-Memory Database[/bold]")
-            store = MetadataStore()
-            if not is_machine:
-                self.console.print("  In-memory database and tables created.")
-
-            if not is_machine:
-                self.console.print("\n[bold]Setup: Loading Tokenizer[/bold]")
-                self.console.print(f"  Loading tokenizer for model: '{cfg.default_embedding_model_name}'...")
-            tokenizer = load_tokenizer(cfg.default_embedding_model_name)
-            if not is_machine:
-                self.console.print(f"    Tokenizer loaded successfully: {tokenizer.__class__.__name__}")
-
-            search_patterns = list(patterns) if patterns else ["*.txt"]
-            files_to_process = gather_files_to_process(path_to_search, search_patterns)
-
-            if not is_machine:
-                if path_to_search.is_file():
-                    self.console.print(f"Processing single file: [green]{path_to_search}[/green]")
-                else:
-                    self.console.print(f"Scanning directory: [green]{path_to_search}[/green] for files matching: {search_patterns}...")
-                    if not files_to_process:
-                        self.console.print(f"[yellow]No files found in directory {path_to_search} with patterns {search_patterns}[/yellow]")
-                    else:
-                        self.console.print(f"Found {len(files_to_process)} file(s) to process.")
-
-            if not files_to_process:
-                if not is_machine:
-                    self.console.print("No files selected for processing. Exiting.")
-                raise typer.Exit()
-
-            all_chunks: List[ChunkData] = []
-            label_counter = 0
-
-            if not is_machine:
-                self.console.print("\n[bold]Step 1 & 2: Processing files, extracting and chunking text (token-based)[/bold]")
-            progress_columns = [
-                SpinnerColumn(),
-                TextColumn("[progress.description]{task.description}"),
-                BarColumn(),
-                TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
-            ]
-            with Progress(*progress_columns, console=self.console, transient=False, disable=is_machine) as progress:
-                task = progress.add_task("Processing files...", total=len(files_to_process))
-                for file_idx, file_path in enumerate(files_to_process):
-                    progress.update(task, description=f"Processing: {file_path.name}")
-                    try:
-                        text = extract_text_from_file(file_path)
-                        if not text.strip():
-                            if not is_machine:
-                                self.console.print(f"    [yellow]Skipped: File '{file_path}' is empty or contains only whitespace.[/yellow]")
-                            progress.advance(task)
-                            continue
-
-                        chunk_infos: List[ProcessedChunkInfo] = chunk_text_by_tokens(
-                            full_text=text,
-                            tokenizer=tokenizer,
-                            chunk_size_tokens=cfg.default_chunk_size_tokens,
-                            overlap_tokens=cfg.default_chunk_overlap_tokens,
-                        )
-                        for c in chunk_infos:
-                            all_chunks.append(
-                                ChunkData(
-                                    text=c.text,
-                                    source_file_path=file_path,
-                                    source_file_id=file_idx,
-                                    usearch_label=label_counter,
-                                    start_char_offset=c.start_char_offset,
-                                    end_char_offset=c.end_char_offset,
-                                    token_count=c.token_count,
-                                )
-                            )
-                            label_counter += 1
-                        if not is_machine:
-                            self.console.print(f"    Extracted {len(chunk_infos)} token-based chunk(s).")
-                    finally:
-                        progress.advance(task)
-
-            if not all_chunks:
-                if not is_machine:
-                    self.console.print("\n[yellow]No text chunks extracted from any files. Cannot perform search.[/yellow]")
-                raise typer.Exit()
-
-            if not is_machine:
-                self.console.print("\n[bold]Setup: Populating In-Memory Database[/bold]")
-            files_meta = {(c.source_file_id, c.source_file_path) for c in all_chunks}
-            store.batch_insert_files(list(files_meta))
-            store.batch_insert_chunks(all_chunks)
-            if not is_machine:
-                self.console.print(f"  Inserted {len(all_chunks)} chunk(s) into DB.")
-
-            if not is_machine:
-                self.console.print(f"\n[bold]Step 3: Generating Embeddings for {len(all_chunks)} total chunk(s)[/bold]")
-            model = load_embedding_model(cfg.default_embedding_model_name)
-            query_embedding = generate_embeddings(
-                texts=[query_text],
-                model_name=cfg.default_embedding_model_name,
-                model=model,
-                is_query=True,
+            perform_persistent_search(
+                query_text=query_text,
+                console=self.console,
+                metadata_store=store,
+                vector_index=index,
+                global_config=cfg,
+                output_mode=output_mode,
+                k_results=top,
+                display_relative_paths=relative_paths,
+                base_path_for_relativity=path_to_search if relative_paths else None,
+                min_score=min_score,
+                file_filter=file_filter,
+                keyword_filter=keyword_filter,
             )
-            chunk_embeddings = generate_embeddings(
-                texts=[c.text for c in all_chunks],
-                model_name=cfg.default_embedding_model_name,
-                model=model,
-                is_query=False,
-            )
-
-            if chunk_embeddings.size == 0:
-                if not is_machine:
-                    self.console.print("  No chunk embeddings available. Skipping vector search.")
-                search_matches: List[SearchResult] = []
-            else:
-                labels_np = np.array([c.usearch_label for c in all_chunks], dtype=np.int64)
-                idx = create_inmemory_index(embeddings=chunk_embeddings, labels_for_usearch=labels_np)
-                search_matches = search_inmemory_index(index=idx, query_embedding=query_embedding, k=top)
-
-            if not is_machine:
-                self.console.print("\n[bold]Step 5: Displaying Results[/bold]")
-
-            if relative_paths and output_mode != OutputMode.paths and not is_machine:
-                self.console.print(
-                    (
-                        "[yellow]Warning: --relative-paths is only effective with --output paths. "
-                        "Paths will be displayed according to the selected output mode.[/yellow]"
-                    )
-                )
-
-            if not search_matches:
-                if output_mode == OutputMode.paths:
-                    self.console.print(format_paths(file_paths=[], use_relative=False, base_path=None, console=self.console))
-                elif output_mode == OutputMode.json:
-                    self.console.print("[]")
-                elif output_mode == OutputMode.count_results:
-                    self.console.print(format_count([]))
-                else:
-                    if not is_machine:
-                        self.console.print("  No relevant chunks found for your query in the processed file(s).")
-                return
-
-            results: List[Dict[str, Any]] = []
-            for match in search_matches:
-                if match.score < min_score:
-                    continue
-                details = store.retrieve_chunk_for_display(match.label)
-                if details:
-                    txt, pth, start_off, end_off = details
-                    results.append(
-                        {
-                            "file_path": pth,
-                            "chunk_text": txt,
-                            "score": match.score,
-                            "start_char_offset": start_off,
-                            "end_char_offset": end_off,
-                            "usearch_label": match.label,
-                        }
-                    )
-
-            results.sort(key=lambda r: r["score"], reverse=True)
-
-            if not results:
-                if output_mode == OutputMode.paths:
-                    self.console.print(format_paths(file_paths=[], use_relative=False, base_path=None, console=self.console))
-                elif output_mode == OutputMode.json:
-                    self.console.print("[]")
-                elif output_mode == OutputMode.count_results:
-                    self.console.print(format_count([]))
-                else:
-                    if not is_machine:
-                        self.console.print("  No relevant chunks found for your query in the processed file(s) (after filtering).")
-                return
-
-            if output_mode == OutputMode.paths:
-                output_paths = [r["file_path"] for r in results]
-                base: Optional[Path] = None
-                if relative_paths:
-                    base = path_to_search if path_to_search.is_dir() else path_to_search.parent
-                out_str = format_paths(
-                    file_paths=output_paths,
-                    use_relative=relative_paths,
-                    base_path=base,
-                    console=self.console,
-                )
-                print(out_str)
-            elif output_mode == OutputMode.show:
-                self.console.print(f"\n[bold cyan]Search Results (Top {len(results)}):[/bold cyan]")
-                for r in results:
-                    out = format_show_basic(file_path=r["file_path"], chunk_text=r["chunk_text"], score=r["score"])
-                    self.console.print("---")
-                    self.console.print(out)
-            elif output_mode == OutputMode.json:
-                print(format_json(results))
-            elif output_mode == OutputMode.count_results:
-                self.console.print(format_count(results))
         finally:
-            if store:
-                if not is_machine:
-                    self.console.print("\n[bold]Cleanup: Closing In-Memory Database[/bold]")
-                store.close()
-                if not is_machine:
-                    self.console.print("  Database connection closed.")
+            store.close()

--- a/simgrep/models.py
+++ b/simgrep/models.py
@@ -55,6 +55,10 @@ class SimgrepConfig(BaseModel):
 
     db_directory: Path = Field(default_factory=lambda: Path("~/.config/simgrep").expanduser())
 
+    ephemeral_cache_dir: Path = Field(
+        default_factory=lambda: Path("~/.config/simgrep/ephemeral_cache").expanduser()
+    )
+
     # centralizing other global defaults from main.py constants / architecture doc:
     # these will be used by persistent indexing logic in later deliverables.
     # ephemeral search in main.py might still use its local constants for now.

--- a/simgrep/utils.py
+++ b/simgrep/utils.py
@@ -1,8 +1,11 @@
+import hashlib
 import tomllib
 from pathlib import Path
 from typing import List, Optional
 
 import pathspec
+
+from .models import SimgrepConfig
 
 
 def gather_files_to_process(path: Path, patterns: List[str]) -> List[Path]:
@@ -65,3 +68,10 @@ def get_project_name_from_local_config(project_root: Path) -> Optional[str]:
         return data.get("project_name")
     except (tomllib.TOMLDecodeError, OSError):
         return None
+
+
+def get_ephemeral_cache_paths(search_root: Path, cfg: SimgrepConfig) -> tuple[Path, Path]:
+    """Return paths for ephemeral cache files based on the search root."""
+    key = hashlib.sha1(str(search_root.resolve()).encode()).hexdigest()[:12]
+    base = cfg.ephemeral_cache_dir / key
+    return base / "metadata.duckdb", base / "index.usearch"

--- a/tests/e2e/test_cli_ephemeral_e2e.py
+++ b/tests/e2e/test_cli_ephemeral_e2e.py
@@ -66,7 +66,7 @@ class TestCliEphemeralE2E:
 
         assert result.exit_code == 0
         if output_mode == "show":
-            assert "Processing:" in result.stdout
+            assert ("Processing:" in result.stdout) or ("Processed:" in result.stdout)
             assert "100%" in result.stdout
         assert validation_fn(result)
 

--- a/tests/unit/test_ephemeral_searcher.py
+++ b/tests/unit/test_ephemeral_searcher.py
@@ -1,152 +1,69 @@
 import pathlib
 from typing import Any, List
 
-import numpy as np
 import pytest
 from rich.console import Console
 
 from simgrep.ephemeral_searcher import EphemeralSearcher
-from simgrep.models import OutputMode, SearchResult
-from simgrep.processor import ProcessedChunk
+from simgrep.models import OutputMode
 
 
-class DummyTokenizer:
-    pass
+class DummyStore:
+    def __init__(self, persistent: bool = False, db_path: pathlib.Path | None = None) -> None:
+        self.path = db_path
+    def close(self) -> None:
+        pass
 
 
-class DummyModel:
-    pass
+class DummyIndexer:
+    calls: List[str] = []
+
+    def __init__(self, config: Any, console: Console) -> None:
+        self.config = config
+        self.console = console
+        DummyIndexer.calls.append("init")
+
+    def run_index(self, paths: List[pathlib.Path], wipe_existing: bool) -> None:
+        self.config.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.config.db_path.write_text("db")
+        self.config.usearch_index_path.write_text("idx")
+        DummyIndexer.calls.append("run_index")
 
 
-def fake_load_tokenizer(model_name: str) -> DummyTokenizer:
-    return DummyTokenizer()
-
-
-def fake_extract_text_from_file(path: pathlib.Path) -> str:
-    return "dummy text for testing"
-
-
-
-def fake_chunk_text_by_tokens(**kwargs: Any) -> List[ProcessedChunk]:
-    return [
-        ProcessedChunk(
-            text="chunk text",
-            start_char_offset=0,
-            end_char_offset=5,
-            token_count=1,
-        )
-    ]
-
-
-def fake_load_embedding_model(name: str) -> DummyModel:
-    return DummyModel()
-
-
-def fake_generate_embeddings(texts: List[str], model_name: str, model: DummyModel | None = None, is_query: bool = False) -> np.ndarray:
-    vec = np.array([0.1, 0.2, 0.3], dtype=np.float32)
-    if is_query:
-        return vec.reshape(1, -1)
-    return np.tile(vec, (len(texts), 1))
-
-
-def fake_create_inmemory_index(**kwargs: Any) -> object:
+def dummy_load_index(path: pathlib.Path) -> object:
+    dummy_load_index.calls += 1
     return object()
 
-
-def fake_search_inmemory_index(**kwargs: Any) -> List[SearchResult]:
-    return [SearchResult(label=0, score=0.9)]
+dummy_load_index.calls = 0
 
 
-@pytest.fixture
-def monkeypatched_searcher(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        "simgrep.ephemeral_searcher.load_tokenizer",
-        fake_load_tokenizer,
-    )
-    monkeypatch.setattr(
-        "simgrep.ephemeral_searcher.extract_text_from_file",
-        fake_extract_text_from_file,
-    )
-    monkeypatch.setattr(
-        "simgrep.ephemeral_searcher.chunk_text_by_tokens",
-        fake_chunk_text_by_tokens,
-    )
-    monkeypatch.setattr(
-        "simgrep.ephemeral_searcher.load_embedding_model",
-        fake_load_embedding_model,
-    )
-    monkeypatch.setattr(
-        "simgrep.ephemeral_searcher.generate_embeddings",
-        fake_generate_embeddings,
-    )
-    monkeypatch.setattr(
-        "simgrep.ephemeral_searcher.create_inmemory_index",
-        fake_create_inmemory_index,
-    )
-    monkeypatch.setattr(
-        "simgrep.ephemeral_searcher.search_inmemory_index",
-        fake_search_inmemory_index,
-    )
+def dummy_perform_search(**kwargs: Any) -> None:
+    dummy_perform_search.calls += 1
+
+dummy_perform_search.calls = 0
 
 
-def test_ephemeral_searcher_show(monkeypatched_searcher: None, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
-    test_file = tmp_path / "file.txt"
-    test_file.write_text("hello")
+@pytest.fixture(autouse=True)
+def patch_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("simgrep.ephemeral_searcher.Indexer", DummyIndexer)
+    monkeypatch.setattr("simgrep.ephemeral_searcher.MetadataStore", DummyStore)
+    monkeypatch.setattr("simgrep.ephemeral_searcher.load_persistent_index", dummy_load_index)
+    monkeypatch.setattr("simgrep.ephemeral_searcher.perform_persistent_search", dummy_perform_search)
+
+
+def test_ephemeral_searcher_caches(tmp_path: pathlib.Path) -> None:
+    src = tmp_path / "file.txt"
+    src.write_text("hello")
 
     console = Console()
     searcher = EphemeralSearcher(console=console)
-    searcher.search(
-        query_text="hello",
-        path_to_search=tmp_path,
-        patterns=["*.txt"],
-        output_mode=OutputMode.show,
-        top=1,
-    )
 
-    out = capsys.readouterr().out
-    assert "Search Results" in out
-    assert "file.txt" in out
+    searcher.search("hello", tmp_path, patterns=["*.txt"], output_mode=OutputMode.json)
+    assert "run_index" in DummyIndexer.calls
+    first_calls = dummy_load_index.calls
 
-
-def test_ephemeral_searcher_no_results(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
-    test_file = tmp_path / "file.txt"
-    test_file.write_text("hello")
-
-    monkeypatch.setattr("simgrep.ephemeral_searcher.search_inmemory_index", lambda **_: [])
-    monkeypatch.setattr(
-        "simgrep.ephemeral_searcher.load_tokenizer",
-        fake_load_tokenizer,
-    )
-    monkeypatch.setattr(
-        "simgrep.ephemeral_searcher.extract_text_from_file",
-        fake_extract_text_from_file,
-    )
-    monkeypatch.setattr(
-        "simgrep.ephemeral_searcher.chunk_text_by_tokens",
-        fake_chunk_text_by_tokens,
-    )
-    monkeypatch.setattr(
-        "simgrep.ephemeral_searcher.load_embedding_model",
-        fake_load_embedding_model,
-    )
-    monkeypatch.setattr(
-        "simgrep.ephemeral_searcher.generate_embeddings",
-        fake_generate_embeddings,
-    )
-    monkeypatch.setattr(
-        "simgrep.ephemeral_searcher.create_inmemory_index",
-        fake_create_inmemory_index,
-    )
-
-    console = Console()
-    searcher = EphemeralSearcher(console=console)
-    searcher.search(
-        query_text="hello",
-        path_to_search=tmp_path,
-        patterns=["*.txt"],
-        output_mode=OutputMode.show,
-        top=1,
-    )
-
-    out = capsys.readouterr().out
-    assert "No relevant chunks found" in out
+    DummyIndexer.calls.clear()
+    searcher.search("hello", tmp_path, patterns=["*.txt"], output_mode=OutputMode.json)
+    assert "run_index" not in DummyIndexer.calls
+    assert dummy_load_index.calls == first_calls + 1
+    assert dummy_perform_search.calls == 2


### PR DESCRIPTION
## Summary
- add ephemeral cache directory to config
- create cache dir at global init
- expose `get_ephemeral_cache_paths` helper
- rewrite `EphemeralSearcher.search` to use on-disk cache
- document the ephemeral cache behaviour
- add test covering caching logic

## Testing
- `make lint`
- `make test` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684afe39e81083339032960be810e205