### PR TITLE
Auto init config on first search

### DIFF
--- a/simgrep/main.py
+++ b/simgrep/main.py
@@ -272,7 +272,17 @@ def search(
     if path_to_search is None:
         persistent_store: Optional[MetadataStore] = None
         try:
-            global_simgrep_config = load_global_config()
+            try:
+                global_simgrep_config = load_global_config()
+            except SimgrepConfigError:
+                if not is_machine_readable_output:
+                    default_cfg = SimgrepConfig()
+                    console.print(f"[yellow]Global config not found. Creating one at {default_cfg.db_directory}[/yellow]")
+                initialize_global_config()
+                global_simgrep_config = load_global_config()
+                if not is_machine_readable_output:
+                    console.print(f"[green]Global simgrep configuration initialized at {global_simgrep_config.db_directory}[/green]")
+
             active_project = get_active_project(project)
 
             if not is_machine_readable_output:
@@ -358,8 +368,12 @@ def search(
         global_simgrep_config = load_global_config()
     except SimgrepConfigError:
         if not is_machine_readable_output:
-            console.print("[dim]Global config not found. Using default settings for ephemeral search.[/dim]")
-        global_simgrep_config = SimgrepConfig()
+            default_cfg = SimgrepConfig()
+            console.print(f"[yellow]Global config not found. Creating one at {default_cfg.db_directory}[/yellow]")
+        initialize_global_config()
+        global_simgrep_config = load_global_config()
+        if not is_machine_readable_output:
+            console.print(f"[green]Global simgrep configuration initialized at {global_simgrep_config.db_directory}[/green]")
 
     context = SimgrepContext.from_defaults(
         model_name=global_simgrep_config.default_embedding_model_name,

--- a/tests/e2e/test_e2e_persistent.py
+++ b/tests/e2e/test_e2e_persistent.py
@@ -290,10 +290,13 @@ class TestIncrementalIndexingE2E:
 
 @pytest.mark.slow
 class TestCliConfigE2E:
-    def test_command_fails_without_global_config(self, temp_simgrep_home: pathlib.Path) -> None:
+    def test_command_auto_initializes_global_config(self, temp_simgrep_home: pathlib.Path) -> None:
+        config_file = temp_simgrep_home / ".config" / "simgrep" / "config.toml"
+        assert not config_file.exists()
         result = run_simgrep_command(["search", "test"])
-        assert result.exit_code == 1
-        assert "Global config not found" in result.stdout
+        assert result.exit_code == 0
+        assert "Global simgrep configuration initialized" in result.stdout
+        assert config_file.exists()
 
     def test_search_fails_on_project_config_load_error(self, temp_simgrep_home: pathlib.Path) -> None:
         """Test the SimgrepConfigError handling block in the search command."""


### PR DESCRIPTION
## Summary
- create global config automatically on first search
- update e2e test to expect auto init

## Testing
- `make format`
- `make test-unit` *(fails: TestUnstructuredExtractor failures)*
- `make test-e2e` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68547742a6c4833384ac98cb50b0682e