### PR TITLE
Switch default model to Qwen/Qwen3-Embedding-0.6B

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -211,7 +211,7 @@ The tool is designed to be intuitive for simple use cases ("semantic grep replac
 
 **5.5. Embedding Model Management**
 
-*   Models specified by their `sentence-transformers` names (e.g., `all-MiniLM-L6-v2`).
+*   Models specified by their Hugging Face names (e.g., `Qwen/Qwen3-Embedding-0.6B`).
 *   The model used for indexing is stored per project.
 *   Changing a project's model will require a full re-index of that project's files. `simgrep index --rebuild` will be necessary.
 *   The tool will download models on first use if not locally cached by `sentence-transformers`.

--- a/simgrep/core/context.py
+++ b/simgrep/core/context.py
@@ -52,7 +52,7 @@ class SimgrepContext:
     @classmethod
     def default(
         cls,
-        model_name: str = "sentence-transformers/all-MiniLM-L6-v2",
+        model_name: str = "Qwen/Qwen3-Embedding-0.6B",
         chunk_size: int = 128,
         chunk_overlap: int = 20,
     ) -> "SimgrepContext":

--- a/simgrep/core/models.py
+++ b/simgrep/core/models.py
@@ -67,7 +67,7 @@ class SimgrepConfig(BaseModel):
     default_project_data_dir: Path = Field(default_factory=lambda: Path("~/.config/simgrep/default_project").expanduser())
     config_file: Path = Field(default_factory=lambda: Path("~/.config/simgrep/config.toml").expanduser())
     db_directory: Path = Field(default_factory=lambda: Path("~/.config/simgrep").expanduser())
-    default_embedding_model_name: str = "sentence-transformers/all-MiniLM-L6-v2"
+    default_embedding_model_name: str = "Qwen/Qwen3-Embedding-0.6B"
     default_chunk_size_tokens: int = 128
     default_chunk_overlap_tokens: int = 20
     model_config = {"validate_assignment": True}

--- a/tests/unit/infrastructure/test_config.py
+++ b/tests/unit/infrastructure/test_config.py
@@ -54,7 +54,7 @@ class TestSimgrepConfig:
             assert isinstance(config, SimgrepConfig)
             assert config.default_project_data_dir == expected_data_dir
             assert config.config_file == expected_config_file
-            assert config.default_embedding_model_name == "sentence-transformers/all-MiniLM-L6-v2"
+            assert config.default_embedding_model_name == "Qwen/Qwen3-Embedding-0.6B"
             assert config.default_chunk_size_tokens == 128
             assert config.default_chunk_overlap_tokens == 20
 
@@ -142,7 +142,7 @@ class TestSimgrepConfig:
             assert config.db_directory == mock_home / ".config" / "simgrep"
 
         # These defaults don't depend on path expansion
-        assert config.default_embedding_model_name == "sentence-transformers/all-MiniLM-L6-v2"
+        assert config.default_embedding_model_name == "Qwen/Qwen3-Embedding-0.6B"
         assert config.default_chunk_size_tokens == 128
         assert config.default_chunk_overlap_tokens == 20
         # assert config.llm_api_key is None # If/when added


### PR DESCRIPTION
## Summary
- default to the new Qwen/Qwen3-Embedding-0.6B model
- document that models are specified by Hugging Face name
- update tests expecting the default model name

## Testing
- `make test-unit`

------
https://chatgpt.com/codex/tasks/task_e_6879faa9c7f08333b4993626db6b3b82